### PR TITLE
docs: v1.0 prep — governance files + secret-rotation runbook

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,42 @@
+---
+name: Bug report
+about: Report a defect in OpenSylab
+title: "[Bug] "
+labels: bug
+assignees: ''
+---
+
+> ⚠️ **Do not report security vulnerabilities here.** See [SECURITY.md](../../SECURITY.md).
+
+## Description
+
+A clear and concise description of the bug.
+
+## Steps to reproduce
+
+1. …
+2. …
+3. …
+
+## Expected behavior
+
+What you expected to happen.
+
+## Actual behavior
+
+What actually happened (include error messages / stack traces / log output).
+
+## Environment
+
+- OpenSylab version (commit or tag):
+- Component: [ ] backend / [ ] frontend / [ ] API / [ ] deployment
+- OS / container:
+- Browser (for frontend issues):
+
+## Audit-trail / compliance impact
+
+Does this affect the audit trail, RBAC, or data integrity? If unsure, say so.
+
+## Additional context
+
+Screenshots, config snippets (redact secrets), or anything else relevant.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/AurevionSec/openSylab/security/advisories/new
+    about: Please report security vulnerabilities privately, not as a public issue.
+  - name: Question / discussion
+    url: https://github.com/AurevionSec/openSylab/discussions
+    about: For questions and general discussion, use GitHub Discussions.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,28 @@
+---
+name: Feature request
+about: Suggest an enhancement for OpenSylab
+title: "[Feature] "
+labels: enhancement
+assignees: ''
+---
+
+## Problem / motivation
+
+What problem does this solve? Who benefits (lab role, deployment scenario)?
+
+## Proposed solution
+
+Describe the feature or change you'd like.
+
+## ISO 15189 / compliance considerations
+
+Does this touch the audit trail, RBAC, or regulated workflows? Describe the
+compliance implications, if any.
+
+## Alternatives considered
+
+Other approaches you evaluated and why you discarded them.
+
+## Additional context
+
+Mockups, references to standards (HL7/FHIR/ISO), or related issues.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,34 @@
+## Summary
+
+What does this PR change and why?
+
+Closes #
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Security fix
+- [ ] Refactor / tech debt
+- [ ] Documentation
+- [ ] Release / version bump
+
+## Checklist
+
+- [ ] Build is clean: 0 errors, 0 new warnings
+- [ ] All tests pass (`ctest --test-dir build` and `npm test` in `frontend/`)
+- [ ] New public functions have tests, including at least one failure path
+- [ ] Data-mutating changes write an `AuditEntry` and enforce an RBAC check (ISO 15189)
+- [ ] No secrets/passwords logged; SQL only via prepared statements
+- [ ] New `.cpp` registered in `CMakeLists.txt`; new test in `test/CMakeLists.txt`
+- [ ] 5-layer architecture respected (no layer N → N+1 or `api/` → `db/` direct import)
+- [ ] `CHANGELOG.md` updated for user-visible changes
+- [ ] Version SSOT unchanged unless this is an intentional release bump
+
+## Security & compliance impact
+
+Describe any impact on authentication, RBAC, audit trail, or patient-data handling.
+
+## How was this tested?
+
+Describe the tests you ran and their results.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,25 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+# Dependabot configuration.
+# Docs: https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+#
+# Note: the C++ backend pulls dependencies via CMake FetchContent and system
+# libraries (OpenSSL, SQLite3), for which Dependabot has no version-update
+# ecosystem. Only the frontend (npm) and GitHub Actions are covered here.
 
 version: 2
 updates:
-  - package-ecosystem: "OpenSylab" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "npm"
+    directory: "/frontend"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      frontend-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,47 @@
 
 All notable changes to this project are documented in this file.
 
+## [Unreleased]
+
+Changes landed on `main` since the v0.9.0 release, tracked toward v1.0.0
+(see `TODO.md` → *v1.0.0 Release Roadmap*).
+
+### Security
+
+- **Resolved all open Dependabot (11) and CodeQL (3) alerts** (#46): `vitest`
+  2.x → 3.2.6 (critical — arbitrary file read/exec via UI server),
+  `vite` → 7.3.5 (high — `server.fs.deny` bypass), `react-router-dom` → 7.15.1
+  (CSRF), plus transitive fixes (`form-data`, `@babel/core`, `esbuild`,
+  `js-yaml`); `npm audit` clean. Least-privilege `permissions: contents: read`
+  added to the CI workflow. Test-data generator (`tools/generate_testdata.py`)
+  now hashes with PBKDF2-HMAC-SHA256 in the backend format instead of plain
+  SHA256.
+
+### Added
+
+- **Project governance** — `SECURITY.md` (private vulnerability reporting),
+  `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md` (Contributor Covenant 2.1),
+  `.github/ISSUE_TEMPLATE/` and `PULL_REQUEST_TEMPLATE.md`.
+- **`docs/SECRET_ROTATION.md`** — JWT-secret rotation runbook, including the
+  caveat that `OPENSYLAB_AUDIT_HMAC_KEY` must not be rotated on a populated
+  database (breaks the audit hash chain).
+- **`TODO.md`** — v1.0.0 release roadmap.
+
+### CI / tooling
+
+- Bump `actions/checkout` and `actions/setup-node` to v5; Node.js 20 → 22.
+- Set `OPENSYLAB_JWT_SECRET` for the CI test runner; remove unused test imports.
+- Fix `.github/dependabot.yml`: invalid `package-ecosystem: "OpenSylab"` replaced
+  with real `npm` (`/frontend`) and `github-actions` (`/`) ecosystems.
+
+### Fixed (documentation)
+
+- Corrected stale framework version in README docs: React 18 → 19 (matches
+  `frontend/package.json`).
+- Corrected the `/api/v1/health` response example to
+  `{"status":"ok","service":"opensylab-lims"}` (the endpoint returns no
+  `version` field).
+
 ## [0.9.0] - 2026-05-25
 
 ### Architecture

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,119 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement through GitHub's
+[private vulnerability reporting](https://github.com/AurevionSec/openSylab/security/advisories/new)
+or by contacting the maintainers privately. All complaints will be reviewed and
+investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact:** Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence:** A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact:** A violation through a single incident or series of actions.
+
+**Consequence:** A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. Violating
+these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact:** A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence:** A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. Violating
+these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact:** Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence:** A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,117 @@
+# Contributing to OpenSylab
+
+Thank you for your interest in contributing. OpenSylab is a medical LIMS —
+correctness, security, and ISO 15189 audit-trail integrity take precedence over
+speed. Please read this guide before opening a pull request.
+
+## Ground rules
+
+- Be respectful — see [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).
+- **Do not** file security vulnerabilities as public issues — see
+  [SECURITY.md](SECURITY.md).
+- Discuss substantial changes in an issue before implementing them.
+
+## Project layout (5-layer architecture)
+
+```
+Layer 4: src/api/    — HTTP endpoints, TLS, routing
+Layer 3: src/auth/   — JWT auth, RBAC enforcement
+Layer 2: src/utils/  — CSV/HL7/FHIR, CLI, config
+Layer 1: src/db/     — SQLite persistence
+Layer 0: src/core/   — domain entities
+```
+
+A layer may only depend on the layer directly below it. `src/api/` must not
+import `src/db/` directly — route through the `IDatabase` interface. No circular
+dependencies.
+
+## Development setup
+
+**Backend (C++17, CMake, OpenSSL, SQLite3):**
+
+```bash
+cmake -B build -DCMAKE_BUILD_TYPE=Debug
+cmake --build build --parallel $(nproc)
+ctest --test-dir build --output-on-failure
+```
+
+Tests require these environment variables (also set in CI):
+
+```bash
+export OPENSYLAB_JWT_SECRET=ci-test-jwt-secret-key-at-least-32-characters-long
+export OPENSYLAB_AUDIT_HMAC_KEY=ci-test-audit-hmac-key-at-least-32-characters-long
+```
+
+**Frontend (React 19 + TypeScript strict, Vite):**
+
+```bash
+cd frontend
+npm install
+npm run build      # tsc -b && vite build
+npm test           # vitest run
+npm run lint
+```
+
+## Coding conventions
+
+**C++**
+
+- C++17. No `// TODO`/`// FIXME`/`// HACK` or commented-out "later" code in merged PRs.
+- RAII for all resources; `unique_ptr`/`shared_ptr` over raw-pointer ownership.
+- Named `constexpr` instead of magic numbers; `static_cast`/`dynamic_cast` over C casts.
+- `const&` for read-only parameters; `const` non-mutating members; `explicit`
+  single-argument constructors.
+- No `std::cout`/`printf` in library code — use the `LOG_*` macros (spdlog).
+- SQL only via prepared statements (`sqlite3_prepare_v2`) — never string
+  concatenation with user input.
+- API handlers return HTTP status codes; do not let exceptions cross module boundaries.
+
+**Frontend**
+
+- TypeScript strict mode, no `any`. API calls only through the central fetch
+  wrapper with auth-header injection.
+
+**Security & compliance (mandatory)**
+
+- Every CREATE/UPDATE/DELETE on Sample, Order, TestResult, or User **must** write
+  an `AuditEntry` (ISO 15189).
+- Every data-mutating endpoint enforces an RBAC role check.
+- Never log passwords or secrets, even at debug level.
+
+## Registering new files
+
+- New `.cpp` → add to the matching `*_SOURCES` set in `CMakeLists.txt`.
+- New test → add to `TEST_SOURCES` in `test/CMakeLists.txt`.
+
+## Tests
+
+- Every new public function needs at least one test.
+- Cover at least one failure path, not only the happy path.
+- Security-relevant functions (auth, RBAC) must also test the rejected case.
+
+## Pull request checklist
+
+Before opening a PR, confirm:
+
+- [ ] Build is clean: 0 errors, 0 new warnings
+- [ ] All tests pass (`ctest` and `npm test`)
+- [ ] New public functions are tested, including a failure path
+- [ ] Audit-trail and RBAC obligations are met for data-mutating changes
+- [ ] `CHANGELOG.md` updated for user-visible changes
+- [ ] Version SSOT untouched unless the PR is an intentional release bump
+      (`CMakeLists.txt` `project(VERSION …)` and `frontend/package.json`)
+
+CI runs the backend build/tests, frontend build/type-check, `npm audit`, and
+CodeQL. All checks must be green before merge.
+
+## Commit & PR style
+
+- Use clear, imperative commit subjects, ideally Conventional Commits
+  (`fix(security): …`, `feat(api): …`, `docs: …`).
+- Keep PRs focused; one logical change per PR.
+- Reference the issue the PR closes.
+
+## License
+
+By contributing, you agree that your contributions are licensed under the
+project's [MIT License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -154,14 +154,14 @@ OpenSylab is **not** suitable for: high-throughput laboratories with >100 concur
 ### Frontend / UX
 | Feature | Description |
 |---------|-------------|
-| **React 18 + TypeScript strict** | No `any` types in production code, 0 TypeScript errors |
+| **React 19 + TypeScript strict** | No `any` types in production code, 0 TypeScript errors |
 | **RBAC in the UI** | `canWrite` guards on all Create/Edit/Delete buttons; sidebar links role-dependent |
 | **Dark mode** | Terminal-industrial aesthetic via `sudo` key sequence (Easter egg) |
 | **Responsive tables** | Secondary columns hidden on tablet (`md:hidden`) |
 | **useEntityList hook** | Universal paginated list hook with abort mechanism, race-condition-safe |
 | **MFA login flow** | Two-step login: credentials → TOTP code |
 | **Secure logout navigation** | Sidebar logout navigates immediately to `/login` |
-| **Health endpoint** | `GET /api/v1/health` — unauthenticated, returns `{"status":"ok","version":"0.9.0"}` |
+| **Health endpoint** | `GET /api/v1/health` — unauthenticated, returns `{"status":"ok","service":"opensylab-lims"}` |
 | **Version SSOT** | `CMakeLists.txt` → `include/version.h` (C++); `package.json` → `VITE_APP_VERSION` (frontend) |
 | **IDatabase interface** | Abstraction layer for testability; `Database` (SQLite) and `PostgreSQLDatabase` both implement `IDatabase` |
 
@@ -188,7 +188,7 @@ OpenSylab is **not** suitable for: high-throughput laboratories with >100 concur
 - **Build**: CMake 3.15+
 
 ### Frontend
-- **Framework**: React 18 + TypeScript (strict mode)
+- **Framework**: React 19 + TypeScript (strict mode)
 - **Build**: Vite 7
 - **Routing**: React Router v6
 - **HTTP**: Axios with JWT interceptor + token-expiry guard
@@ -270,7 +270,7 @@ OPENSYLAB_CORS_ORIGIN="https://lims.meinlabor.de" \
 
 ```
 ┌─────────────────────────────────────────────────┐
-│  Frontend (React 18 / TypeScript)               │
+│  Frontend (React 19 / TypeScript)               │
 │  http://localhost:5173                          │
 └──────────────────┬──────────────────────────────┘
                    │ HTTPS / JWT

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,55 @@
+# Security Policy
+
+OpenSylab processes medical laboratory data. We take security reports seriously
+and appreciate responsible disclosure.
+
+## Supported versions
+
+Security fixes are provided for the latest released minor version. Older versions
+receive fixes only at the maintainers' discretion.
+
+| Version | Supported |
+|---------|-----------|
+| 0.9.x   | ✅        |
+| < 0.9   | ❌        |
+
+## Reporting a vulnerability
+
+**Please do not open a public GitHub issue for security vulnerabilities.**
+
+Report privately through GitHub's **[Private vulnerability reporting](https://github.com/AurevionSec/openSylab/security/advisories/new)**
+(Security → Advisories → *Report a vulnerability*). This keeps the report
+confidential until a fix is available.
+
+Please include, where possible:
+
+- Affected component and version / commit
+- A description of the vulnerability and its impact (e.g. authentication bypass,
+  audit-trail tampering, patient-data exposure)
+- Steps to reproduce or a proof of concept
+- Any suggested remediation
+
+## What to expect
+
+- **Acknowledgement:** within 5 business days
+- **Initial assessment:** within 10 business days
+- **Fix & disclosure:** coordinated with the reporter; we aim to release a fix
+  before public disclosure and will credit reporters who wish to be named
+
+## Scope
+
+In scope: the OpenSylab backend (C++), frontend (React/TypeScript), API, and the
+default deployment configuration.
+
+Particularly sensitive areas — please prioritise these in reports:
+
+- Authentication and JWT handling (`src/auth/`, `src/api/ApiServer.cpp`)
+- RBAC enforcement (role checks on API endpoints)
+- Audit-trail integrity (HMAC-SHA256 hash chain, `Database::addAuditEntry`)
+- SQL query construction (prepared-statement usage)
+- TLS / transport configuration
+
+Out of scope: vulnerabilities in third-party dependencies already tracked by
+Dependabot (report those upstream), issues requiring a compromised host or
+physical access, and the documented development defaults (`admin/admin`, dev JWT
+secret) which must never be used in production.

--- a/TODO.md
+++ b/TODO.md
@@ -6,6 +6,72 @@
 
 ---
 
+## 🎯 v1.0.0 — Release Roadmap (analysis 2026-07-04)
+
+Verified against the actual codebase (not just checkbox state). The core code is
+mature and marker-clean (0 TODO/FIXME/HACK/stub in `src/`+`include/`); the road to
+1.0 is **hardening, compliance documentation and release engineering**, not a large
+feature build. For a medical LIMS, "1.0" means production-ready + ISO 15189 story.
+
+### 🔴 P0 — 1.0 blockers
+
+- [ ] **Split `ApiServer.cpp` God-file (4053 lines)** — `src/api/ApiServer.cpp`.
+      All ~30 route handlers, URL decoder, rate limiter, CORS in one file (grew
+      from ~3400). Biggest maintainability risk for a "stable API" 1.0.
+      Split into `SampleHandler`, `OrderHandler`, `ResultHandler`, `UserHandler`,
+      `AuditHandler`, `StatsHandler`, `Hl7Handler`, `FhirHandler`.
+      Effort: ~3–4 weeks.
+- [ ] **Release engineering**
+      - Version bump 0.9.0 → 1.0.0 in `CMakeLists.txt` (C++ SSOT) **and**
+        `frontend/package.json` (Frontend SSOT)
+      - `CHANGELOG.md`: add `[1.0.0]` section — the 4 currently unreleased commits
+        (security fix #46, CI bumps) are undocumented; no `[Unreleased]` section exists
+      - Git tag `v1.0.0` + GitHub release
+      - Baseline gate: fresh `cmake --build` + `ctest` green confirmed before tagging
+- [ ] **ISO 15189 IQ/OQ/PQ validation package (STR-1)** — does not exist yet.
+      The real gatekeeper for accredited-lab production use. Documentation +
+      reproducible OQ test scripts. Effort: ~6–10 weeks (can run in parallel).
+      *Optional for a lean 1.0 — see scope note below.*
+
+### 🟡 P1 — Governance & Ops (expected of a serious public medical 1.0)
+
+- [ ] **`SECURITY.md`** — vulnerability reporting policy (repo currently has none)
+- [ ] **`CONTRIBUTING.md`** — contribution guide
+- [ ] **`CODE_OF_CONDUCT.md`** — code of conduct
+- [ ] **`.github/ISSUE_TEMPLATE/` + `PULL_REQUEST_TEMPLATE.md`** — issue/PR templates
+- [x] **JWT secret rotation** (was P3) — documented in
+      [`docs/SECRET_ROTATION.md`](docs/SECRET_ROTATION.md): rotation procedure,
+      all-tokens-invalidated effect, restart requirement (no hot-reload), and the
+      critical caveat that `OPENSYLAB_AUDIT_HMAC_KEY` must **not** be rotated on a
+      populated DB (breaks the audit hash chain). A hot-reload mechanism remains a
+      v1.x nice-to-have.
+- [ ] **Branch protection / merge process** — PR #46 required an admin override to
+      merge (ruleset requires review). Establish a clean review gate for 1.0.
+
+### 🟢 P2 — Tech debt (1.0-compatible, tackle before 1.1)
+
+- [ ] **No E2E / integration tests** (Playwright/Cypress) — advisable for medical
+      software, not a hard 1.0 blocker
+- [ ] **Custom test-macro framework** instead of Catch2/GoogleTest — cosmetic
+- [ ] **PostgreSQL backend** — deliberately deferred to v1.1 (stub blocks startup).
+      **Not a 1.0 blocker.**
+
+### Scope recommendation
+
+- **Lean, honest 1.0 (~4–6 weeks):** release engineering + governance files +
+  JWT-rotation docs + `ApiServer.cpp` split. Defer IQ/OQ/PQ and E2E to 1.0.x/1.1.
+- **Full "lab-ready 1.0" (~10–14 weeks):** additionally IQ/OQ/PQ package (STR-1)
+  and E2E tests — then deployable in an accredited laboratory.
+
+### Corrected stale entries (already done — no effort needed)
+
+- `token_expiry`/`_expiry` mismatch → **not a bug**: `auth.ts` and `api.ts` both
+  use key `opensylab_token_expiry` (`_expiry` is only a local variable name)
+- "JSON parser limitations" → resolved via nlohmann/json in v0.9.0
+- TOTP Base32 enrollment flow → implemented in v0.9.0 (checkbox below was stale)
+
+---
+
 ## ✅ v0.7.0 — Completed (2026-05-11)
 
 Full change list: [CHANGELOG.md](CHANGELOG.md#070---2026-05-11)
@@ -85,8 +151,8 @@ Highlights: Rate Limiting · Forced password change · Enforce HTTPS · Health e
 - [x] **CORS duplication** — `getenv("OPENSYLAB_CORS_ORIGIN")` is read separately in
       `handleClientTls()` and `handleClientPlain()` (2 locations)
 - [x] **Multi-threaded server / concurrency** — done in v0.9.0 (thread-per-connection, max 32 concurrent, 503 on overflow)
-- [ ] **Secret key rotation** — no documented process for rotating
-      the JWT secret without a server restart
+- [x] **Secret key rotation** — documented in `docs/SECRET_ROTATION.md`
+      (rotation requires a restart; hot-reload deferred to v1.x)
 
 ---
 
@@ -107,13 +173,14 @@ P0 complete + health endpoint + HL7/FHIR endpoints + breadcrumb fix + TESTING.md
 
 ## Known technical debt (not a release blocker)
 
-- `token_expiry` key is written in `auth.ts` but read as `_expiry` in `api.ts`
-  — if the key is missing, silent logout on every request
+- ~~`token_expiry` key written in `auth.ts` but read as `_expiry` in `api.ts`~~
+  — **resolved / not a bug**: both use key `opensylab_token_expiry`; `_expiry` is
+  only a local variable name in `api.ts`
 - Test runner uses its own macro framework instead of Catch2/GoogleTest → no
   standard CI output without custom scripts
 - No E2E/integration tests (Playwright/Cypress)
-- **JSON parser limitations** — hand-written parser in `ApiServer.cpp`
-  does not support arrays or nested objects; complicates API expansion.
+- ~~**JSON parser limitations** — hand-written parser in `ApiServer.cpp`~~
+  — **resolved** in v0.9.0 (replaced by nlohmann/json v3.11.3)
 
 ---
 
@@ -141,13 +208,9 @@ P0 complete + health endpoint + HL7/FHIR endpoints + breadcrumb fix + TESTING.md
 - [x] **No JWT token blacklisting after logout** — Tokens remain valid until expiry
       (60 min). With compromised credentials the attacker is authorized for that
       window. Fix: in-memory blacklist in ApiRouter + `POST /api/v1/auth/logout`.
-- [ ] **TOTP Base32 enrollment flow** — Secrets stored as raw strings are incompatible
-      with standard authenticator apps (Google Authenticator, Authy) that expect
-      Base32-encoded secrets for QR code enrollment. `base32Decode()` utility added
-      to `Database.cpp`. Proper fix requires: (1) new MFA enrollment API endpoint
-      that generates a Base32 secret and returns a `otpauth://` URI for QR display,
-      (2) DB migration to re-encode existing raw secrets as Base32,
-      (3) update `computeMfaCode` to decode Base32 before HMAC.
+- [x] **TOTP Base32 enrollment flow** — done in v0.9.0 (see v0.9.0 section below:
+      `generateMfaSecret()`, `base32Encode()`, `getMfaEnrollmentUri()` returning an
+      `otpauth://` URI, and the `/auth/mfa/*` endpoints). This entry was stale.
 
 ### Architecture debt (medium to long term)
 
@@ -259,4 +322,4 @@ With a recognized certificate "Certified OpenSylab Administrator".
 
 ---
 
-*Last updated: 2026-05-16 — Strategic Analysis*
+*Last updated: 2026-07-04 — v1.0.0 roadmap analysis (verified against codebase)*

--- a/docs/SECRET_ROTATION.md
+++ b/docs/SECRET_ROTATION.md
@@ -1,0 +1,152 @@
+# Secret Rotation Runbook
+
+OpenSylab depends on two cryptographic secrets, both supplied via environment
+variables and both **mandatory at startup** (the server hard-fails if either is
+missing or shorter than 32 characters):
+
+| Secret | Purpose | Rotatable? |
+|--------|---------|------------|
+| `OPENSYLAB_JWT_SECRET` | Signs/verifies JWT session tokens | ✅ Yes — see below |
+| `OPENSYLAB_AUDIT_HMAC_KEY` | Keys the tamper-evident audit-trail hash chain | ⚠️ **No** on a populated database — see caveat |
+
+This runbook documents the supported rotation procedure for the JWT secret and
+the constraints around the audit HMAC key.
+
+---
+
+## 1. Rotating the JWT secret (`OPENSYLAB_JWT_SECRET`)
+
+### When to rotate
+
+- **Immediately** on suspected compromise (leaked secret, compromised host,
+  departing operator with production access).
+- **Periodically** as policy (e.g. quarterly) for defence in depth.
+
+### Effect of rotation
+
+The JWT secret is read once, when the API router is constructed at server start
+(`src/api/ApiServer.cpp`, `ApiRouter` constructor). Tokens are signed with
+HMAC using this secret and expire after **60 minutes**.
+
+Rotating the secret means every previously issued token fails signature
+validation and is rejected. **Consequence: all logged-in users are signed out
+and must re-authenticate.** There is no partial invalidation — it is all-or-nothing.
+
+### Procedure
+
+1. **Generate a new secret** (≥32 characters, high entropy):
+
+   ```bash
+   openssl rand -hex 32
+   ```
+
+2. **Install the new value** in whichever mechanism your deployment uses:
+
+   - **Bare process / systemd:** update the environment file (e.g.
+     `EnvironmentFile=` target) with the new `OPENSYLAB_JWT_SECRET`.
+   - **Docker Compose:** update `OPENSYLAB_JWT_SECRET` in `docker-compose.yml`
+     (or, preferably, the `.env` file / secret store it references).
+   - **Secret manager (Vault, AWS/GCP Secrets Manager, etc.):** update the stored
+     value and ensure the container/process reads the new version on next start.
+
+   The secret must be **≥32 characters** and present, otherwise the server
+   **hard-fails at startup** (`ApiRouter` constructor). Additionally, a secret
+   containing the substrings `dev` or `change` is treated as a development
+   placeholder and logs a `[SECURITY WARNING]` — avoid those in production values.
+
+3. **Restart the server** so the new secret is loaded:
+
+   ```bash
+   # Docker
+   docker compose up -d --force-recreate opensylab-backend
+
+   # systemd
+   sudo systemctl restart opensylab
+   ```
+
+   > There is currently **no hot-reload** of the JWT secret without a restart.
+   > A restart is required for the new secret to take effect.
+
+4. **Verify** (see section 3).
+
+### Multi-instance / zero-downtime note
+
+The secret is per-process. During a rolling restart of multiple backend
+instances, tokens signed by an already-restarted instance (new secret) will be
+rejected by not-yet-restarted instances (old secret) and vice versa. For a clean
+rotation, prefer a brief maintenance window, or accept that users may need to log
+in again during the rollout. Because tokens live only 60 minutes, the disruption
+window is naturally bounded.
+
+---
+
+## 2. Audit HMAC key (`OPENSYLAB_AUDIT_HMAC_KEY`) — do not rotate on a populated DB
+
+The audit trail is a tamper-evident hash chain: each `audit_log` row stores a
+`chain_hash` computed as an HMAC-SHA256 over the entry's canonical fields **and**
+the previous row's `chain_hash`, keyed by `OPENSYLAB_AUDIT_HMAC_KEY`
+(`src/db/Database.cpp`). The `GET /api/v1/audit/verify` endpoint (ADMIN-only)
+recomputes the entire chain with the **current** key and reports the first entry
+whose hash does not match.
+
+**Therefore: changing `OPENSYLAB_AUDIT_HMAC_KEY` on a database that already
+contains audit entries will make the whole existing chain fail verification** —
+every historical entry recomputes to a different HMAC, and `audit/verify` will
+report the chain as broken from the first row. This is an ISO 15189 integrity
+concern, not just an inconvenience.
+
+Guidance:
+
+- **Set this key once, before the first audit entry is written, and keep it
+  stable for the lifetime of the database.**
+- Store it in a secret manager; back it up alongside (but not in) the database.
+  Losing it means the existing chain can no longer be verified.
+- A safe re-keying of an existing chain would require re-signing every entry with
+  the new key and recording that administrative action in the audit trail itself.
+  **This is not currently supported** and must not be improvised by editing the
+  environment variable. Track this under the v1.x roadmap (secret-rotation
+  tooling) if a re-key capability is required.
+
+If you must migrate to a new key for a fresh deployment, do so on an empty
+`audit_log` (new database), not on production history.
+
+---
+
+## 3. Post-rotation verification
+
+After rotating the JWT secret and restarting:
+
+1. **Health check** — server is up:
+
+   ```bash
+   curl -s http://localhost:8080/api/v1/health
+   # {"status":"ok","service":"opensylab-lims"}
+   ```
+
+2. **Fresh login works** with the new secret:
+
+   ```bash
+   curl -s -X POST http://localhost:8080/api/v1/auth/login \
+     -H "Content-Type: application/json" \
+     -d '{"username":"<user>","password":"<password>"}'
+   # returns a new token
+   ```
+
+3. **Old tokens are rejected** — a request with a pre-rotation token returns
+   HTTP 401.
+
+4. **Audit chain still verifies** (confirms you did *not* accidentally change the
+   HMAC key):
+
+   ```bash
+   curl -s http://localhost:8080/api/v1/audit/verify \
+     -H "Authorization: Bearer <new-admin-token>"
+   # {"valid":true,"message":"Audit chain integrity verified"}
+   ```
+
+---
+
+## Related
+
+- Environment variables reference: [`docs/DOCKER.md`](DOCKER.md)
+- Security policy / vulnerability reporting: [`../SECURITY.md`](../SECURITY.md)

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -8,7 +8,7 @@ Modern React TypeScript frontend for the OpenSylab Laboratory Information Manage
 
 ## Tech Stack
 
-- **Framework**: React 18 with TypeScript
+- **Framework**: React 19 with TypeScript
 - **Build Tool**: Vite 5 with Hot Module Replacement
 - **Routing**: React Router v6
 - **HTTP Client**: Axios with JWT interceptors


### PR DESCRIPTION
Two gatekeeper-approved iterations toward **1.0 readiness** (tracked in the new `TODO.md` → *v1.0.0 Release Roadmap*). Docs/governance only — no source-code behavior change.

## Iteration 1 — Project governance (P1)
- **SECURITY.md** — private vulnerability reporting (GitHub advisories), scope, response SLAs, sensitive-area list
- **CONTRIBUTING.md** — 5-layer architecture, build/test setup with required env vars, C++/frontend conventions, audit-trail + RBAC rules, PR checklist
- **CODE_OF_CONDUCT.md** — Contributor Covenant 2.1
- **.github/ISSUE_TEMPLATE/** (bug, feature, config) + **PULL_REQUEST_TEMPLATE.md**
- **.github/dependabot.yml** — fixes invalid `package-ecosystem: "OpenSylab"` → real `npm` (`/frontend`) + `github-actions` (`/`) with grouping

## Iteration 2 — Operations (P1)
- **docs/SECRET_ROTATION.md** — JWT-secret rotation runbook (procedure, all-tokens-invalidated, restart required / no hot-reload) + **critical caveat**: `OPENSYLAB_AUDIT_HMAC_KEY` must **not** be rotated on a populated DB (breaks the ISO 15189 audit hash chain); post-rotation verification steps

## Doc-accuracy fixes (verified against source)
- README / frontend README: **React 18 → 19** (matches `package.json` `^19.2.6`)
- README + rotation doc: health response corrected to `{"status":"ok","service":"opensylab-lims"}` (code returns **no** `version` field — `ApiServer.cpp:670`)
- TODO.md: v1.0.0 roadmap added; stale entries corrected; secret-rotation items checked off

## Review
Each iteration was reviewed by a strict gatekeeper agent (standing in for Gemini) and iterated to **APPROVED**. Both defects it caught (React version, fictitious health `version` field) are fixed.

> ⚠️ **Gemini re-verification pending.** The configured `GEMINI_API_KEY` project has no active billing (API returns free-tier quota, exhausted for the day). Once billing/quota is available, Gemini will re-verify per the CLAUDE.md gatekeeper workflow.

## Not in this PR (need dedicated effort)
The two P0 1.0 blockers remain: `ApiServer.cpp` split (~4053 lines) and the ISO 15189 IQ/OQ/PQ validation package. See `TODO.md`.

https://claude.ai/code/session_01QwRSUQRhHR4mkfvvaoqnYJ