### PR TITLE
chore(release): bump to v1.0.0 + finalize CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,20 @@
 
 All notable changes to this project are documented in this file.
 
-## [Unreleased]
+## [1.0.0] - 2026-07-05
 
-Changes landed on `main` since the v0.9.0 release, tracked toward v1.0.0
-(see `TODO.md` → *v1.0.0 Release Roadmap*).
+First 1.0 release. Consolidates the post-0.9.0 hardening, governance,
+architecture, and test work.
+
+### Architecture
+
+- **`ApiServer.cpp` God-function decomposition (Phase A)** (#48, #62, #63) —
+  `ApiRouter::handleRequest` reduced from **2781 → 440 lines** by extracting
+  every inline route branch into a dedicated per-route handler method, threading
+  a shared `RouteContext` (write handlers also receive the parsed body map).
+  All ~30 routes extracted (health/openapi, audit, stats, HL7/FHIR, MFA, users,
+  and samples/orders/results across GET/POST/PUT/DELETE). Behaviour-preserving:
+  each step verified by an independent review plus the full unit-test suite.
 
 ### Security
 
@@ -42,6 +52,14 @@ Changes landed on `main` since the v0.9.0 release, tracked toward v1.0.0
 - Corrected the `/api/v1/health` response example to
   `{"status":"ok","service":"opensylab-lims"}` (the endpoint returns no
   `version` field).
+
+### Tests
+
+- **API-layer compliance coverage** (#64) — HTTP-level regression tests through
+  `ApiRouter::handleRequest` for the ISO 15189 branches relocated during the
+  refactor: immutability guards (409), invalid status-transition rejection (409),
+  ADMIN-only VALIDATE enforcement (403), and delete guards (active-orders 409,
+  idempotent REJECTED 204, VALIDATED 409). Suite now at 235 unit tests.
 
 ## [0.9.0] - 2026-05-25
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.15)
 
 # Projektdefinition
 project(OpenSylab
-    VERSION 0.9.0
+    VERSION 1.0.0
     DESCRIPTION "Open Source Laboratory Information Management System (LIMS)"
     LANGUAGES CXX
 )

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 **Open-source LIMS for medical diagnostics — ISO 15189-compliant, self-hosted, MIT-licensed.**
 
-[![Version](https://img.shields.io/badge/version-0.9.0-blue)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.0.0-blue)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-MIT-green)](#license)
 [![Tests](https://img.shields.io/badge/tests-228%20passing-brightgreen)](#tests)
 [![C++](https://img.shields.io/badge/C%2B%2B-17-orange)](src/)
-[![React](https://img.shields.io/badge/React-18-61dafb)](frontend/)
+[![React](https://img.shields.io/badge/React-19-61dafb)](frontend/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-strict-blue)](frontend/src/)
 [![Security](https://img.shields.io/badge/security-PBKDF2%20%7C%20JWT%20%7C%20TOTP%20%7C%20HMAC--chain-red)](#security)
 
@@ -110,7 +110,7 @@ OpenSylab is **not** suitable for: high-throughput laboratories with >100 concur
 
 ---
 
-## Features — v0.9.0
+## Features — v1.0.0
 
 ### Laboratory Data Management
 | Feature | Description |

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "0.9.0",
+  "version": "1.0.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Release engineering for **v1.0.0** (final lean-1.0 blocker in `TODO.md`).

## Version bump
- `CMakeLists.txt` `project(VERSION)` 0.9.0 → **1.0.0** (C++ SSOT → regenerates `include/version.h` = `"1.0.0"`)
- `frontend/package.json` 0.9.0 → **1.0.0** (frontend SSOT)
- README: version badge → 1.0.0, React badge 18 → **19** (was stale), Features heading → v1.0.0

## CHANGELOG
`[Unreleased]` → **`[1.0.0] - 2026-07-05`**, adding the entries that landed after #47:
- Architecture: ApiServer `handleRequest` decomposition Phase A (#48/#62/#63) — 2781 → 440 lines
- Tests: API-layer compliance coverage (#64) — 235 tests

## Baseline gate
Reconfigure + build clean (0 errors, 0 warnings); **all 235 unit tests pass**.

## ⚠️ Not included by design
This PR does **not** create the `v1.0.0` git tag or the GitHub release. Cutting the release is an outward-facing, deliberate step left for explicit maintainer authorization — do it after this merges (e.g. `git tag -a v1.0.0 && gh release create v1.0.0`).

https://claude.ai/code/session_01QwRSUQRhHR4mkfvvaoqnYJ