### PR TITLE
test(e2e): Playwright end-to-end suite (real backend + frontend)

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -27,3 +27,7 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+test-results/
+playwright-report/
+blob-report/
+/playwright/.cache/

--- a/frontend/e2e/auth.spec.ts
+++ b/frontend/e2e/auth.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Authentication', () => {
+  test('logs in with the seeded admin credentials and reaches the app', async ({
+    page,
+  }) => {
+    await page.goto('/login')
+    await page.getByLabel('Username').fill('admin')
+    await page.getByLabel('Password').fill('admin')
+    await page.getByRole('button', { name: 'Sign In' }).click()
+
+    // Redirected off /login into the authenticated shell.
+    await expect(page).not.toHaveURL(/\/login/)
+    await expect(page.getByRole('link', { name: 'Samples' })).toBeVisible()
+  })
+
+  test('rejects invalid credentials and stays on the login page', async ({
+    page,
+  }) => {
+    await page.goto('/login')
+    await page.getByLabel('Username').fill('admin')
+    await page.getByLabel('Password').fill('definitely-wrong-password')
+    await page.getByRole('button', { name: 'Sign In' }).click()
+
+    // An error alert appears (exact wording is the backend's to decide) and we
+    // stay on the login page — no token, no redirect.
+    const alert = page.getByRole('alert')
+    await expect(alert).toBeVisible()
+    await expect(alert).toContainText(/invalid|incorrect|password/i)
+    await expect(page).toHaveURL(/\/login/)
+  })
+})

--- a/frontend/e2e/config.ts
+++ b/frontend/e2e/config.ts
@@ -1,0 +1,8 @@
+// Shared E2E endpoints. A non-standard backend port is used deliberately so the
+// suite never collides with other services a developer may run on 8080/9080.
+export const BACKEND_PORT = 18080
+export const BACKEND_URL = `http://localhost:${BACKEND_PORT}`
+export const API_BASE = `${BACKEND_URL}/api/v1`
+
+export const FRONTEND_PORT = 5173
+export const FRONTEND_URL = `http://localhost:${FRONTEND_PORT}`

--- a/frontend/e2e/navigation.spec.ts
+++ b/frontend/e2e/navigation.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from '@playwright/test'
+import { API_BASE } from './config'
+
+// Log in once per test via the real login flow, then exercise navigation.
+test.beforeEach(async ({ page }) => {
+  await page.goto('/login')
+  await page.getByLabel('Username').fill('admin')
+  await page.getByLabel('Password').fill('admin')
+  await page.getByRole('button', { name: 'Sign In' }).click()
+  await expect(page.getByRole('link', { name: 'Samples' })).toBeVisible()
+})
+
+const sections = [
+  { name: 'Samples', path: '/samples' },
+  { name: 'Orders', path: '/orders' },
+  { name: 'Results', path: '/results' },
+  { name: 'Audit Log', path: '/audit-log' },
+]
+
+for (const { name, path } of sections) {
+  test(`navigates to ${name} and loads the page`, async ({ page }) => {
+    await page.getByRole('link', { name }).click()
+    await expect(page).toHaveURL(new RegExp(path.replace('/', '\\/')))
+    // The authenticated shell (sidebar) is still present after navigation.
+    await expect(page.getByRole('link', { name: 'Dashboard' })).toBeVisible()
+  })
+}
+
+test('reads samples from the backend (empty DB → total 0)', async ({
+  request,
+}) => {
+  // Drive the API the same way the SPA does, using a token from a real login.
+  const login = await request.post(`${API_BASE}/auth/login`, {
+    data: { username: 'admin', password: 'admin' },
+  })
+  expect(login.ok()).toBeTruthy()
+  const { token } = await login.json()
+  const samples = await request.get(`${API_BASE}/samples`, {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+  expect(samples.ok()).toBeTruthy()
+  expect(await samples.json()).toMatchObject({ data: [], total: 0 })
+})

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,6 +16,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
+        "@playwright/test": "^1.61.1",
         "@tailwindcss/postcss": "^4.3.2",
         "@testing-library/jest-dom": "^6.0.0",
         "@testing-library/react": "^16.0.0",
@@ -963,6 +964,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@reduxjs/toolkit": {
@@ -4772,6 +4789,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,9 @@
     "preview": "vite preview",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "axios": "^1.18.1",
@@ -21,6 +23,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
+    "@playwright/test": "^1.61.1",
     "@tailwindcss/postcss": "^4.3.2",
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^16.0.0",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,49 @@
+import { defineConfig, devices } from '@playwright/test'
+import { API_BASE, BACKEND_PORT, BACKEND_URL, FRONTEND_URL } from './e2e/config'
+
+// End-to-end tests drive the real app: the C++ backend (built at
+// ../build/bin/OpenSylab) plus the Vite dev server, wired together over HTTP.
+// The backend runs on a non-standard port (see e2e/config.ts) to avoid
+// colliding with other services on 8080/9080.
+export default defineConfig({
+  testDir: './e2e',
+  testMatch: '**/*.spec.ts',
+  timeout: 30_000,
+  expect: { timeout: 10_000 },
+  fullyParallel: false,
+  workers: 1,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? [['github'], ['list']] : 'list',
+  use: {
+    baseURL: FRONTEND_URL,
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+  webServer: [
+    {
+      // Fresh DB each run so the seeded admin/admin account is deterministic.
+      command: `sh -c "rm -f /tmp/opensylab-e2e.db* && exec ../build/bin/OpenSylab --api --api-port ${BACKEND_PORT}"`,
+      url: `${BACKEND_URL}/api/v1/health`,
+      timeout: 60_000,
+      reuseExistingServer: !process.env.CI,
+      env: {
+        OPENSYLAB_JWT_SECRET: 'e2e-playwright-jwt-secret-at-least-32-characters',
+        OPENSYLAB_AUDIT_HMAC_KEY:
+          'e2e-playwright-audit-hmac-at-least-32-characters',
+        OPENSYLAB_DB_PATH: '/tmp/opensylab-e2e.db',
+        OPENSYLAB_CORS_ORIGIN: FRONTEND_URL,
+      },
+    },
+    {
+      // VITE_API_URL via process.env overrides any .env.local (Vite gives
+      // pre-existing env vars the highest priority).
+      command: 'npm run dev -- --port 5173 --strictPort',
+      url: FRONTEND_URL,
+      timeout: 60_000,
+      reuseExistingServer: !process.env.CI,
+      env: { VITE_API_URL: API_BASE },
+    },
+  ],
+})

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -22,5 +22,5 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["vite.config.ts"]
+  "include": ["vite.config.ts", "playwright.config.ts", "e2e"]
 }

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -6,6 +6,10 @@ export default mergeConfig(viteConfig, defineConfig({
     globals: true,
     environment: 'happy-dom',
     setupFiles: ['./src/test/setup.ts'],
+    // Unit tests live under src/; the Playwright e2e specs (e2e/**) must not be
+    // picked up by Vitest.
+    include: ['src/**/*.{test,spec}.{ts,tsx}'],
+    exclude: ['**/node_modules/**', '**/dist/**', 'e2e/**'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],


### PR DESCRIPTION
Adds the first **true end-to-end tests** — the last open test-coverage gap. Playwright boots the real app and drives it in Chromium:
- **backend**: `../build/bin/OpenSylab --api` on port **18080** (non-standard, to avoid clashing with other local services on 8080/9080), fresh DB + test secrets
- **frontend**: Vite dev server with `VITE_API_URL` pointed at that backend

### Suite (7 tests, all green locally)
- **auth**: seeded `admin/admin` login reaches the app; invalid credentials → error alert + stay on `/login`
- **navigation**: Samples / Orders / Results / Audit Log load within the authenticated shell
- **api**: a token from a real login reads `GET /samples` (empty DB → `{data:[],total:0}`)

### Details
- `playwright.config.ts` webServer auto-starts both servers; ports/URLs centralised in `e2e/config.ts`
- `npm run test:e2e` (+ `:ui`); `@playwright/test` devDependency
- `tsconfig.node.json` includes the config + `e2e` (type-checked by `tsc -b`)
- `.gitignore` for Playwright artefacts

**Run locally:** `cmake --build build` once, then `cd frontend && npm run test:e2e`.

**Follow-up:** wire E2E into CI (build backend → `playwright install --with-deps chromium` → run). Kept separate so this PR is a clean, reviewable unit. This PR does not run e2e in CI, but CI now type-checks the specs via `tsc -b`.

https://claude.ai/code/session_01QwRSUQRhHR4mkfvvaoqnYJ