### PR TITLE
ci: run the Playwright E2E suite in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,3 +68,47 @@ jobs:
         run: npm run build
         env:
           VITE_API_URL: http://localhost:9080/api/v1
+
+  e2e:
+    name: E2E (Playwright)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install backend build dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y cmake libssl-dev libsqlite3-dev
+
+      - name: Build backend
+        run: |
+          cmake -B build -DCMAKE_BUILD_TYPE=Release
+          cmake --build build --parallel "$(nproc)"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Install Playwright browser
+        working-directory: frontend
+        run: npx playwright install --with-deps chromium
+
+      - name: Run E2E tests
+        working-directory: frontend
+        # Playwright boots ../build/bin/OpenSylab + the Vite dev server itself.
+        run: npm run test:e2e
+
+      - name: Upload Playwright report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: frontend/playwright-report/
+          retention-days: 7


### PR DESCRIPTION
Completes the E2E work (#71) by gating the pipeline on it.

New **E2E (Playwright)** job:
1. builds the C++ backend (Release) → `build/bin/OpenSylab`
2. sets up Node + `npm ci` (frontend)
3. `npx playwright install --with-deps chromium`
4. `npm run test:e2e` — Playwright boots the backend binary (port 18080) + Vite dev server and runs the 7 tests in Chromium
5. uploads the Playwright HTML report as an artifact

GitHub sets `CI=true`, so `playwright.config.ts` starts fresh servers (no reuse) and `forbidOnly` is on. Self-contained (no cross-job artifacts).

https://claude.ai/code/session_01QwRSUQRhHR4mkfvvaoqnYJ