### PR TITLE
fix(frontend): resolve real react-hooks lint findings (18 → 14 warnings)

### DIFF
--- a/frontend/src/components/Samples/SampleCreateModal.tsx
+++ b/frontend/src/components/Samples/SampleCreateModal.tsx
@@ -25,10 +25,13 @@ export const SampleCreateModal = ({ isOpen, onClose, onSuccess }: SampleCreateMo
   const [error, setError] = useState('');
 
   const [showBarcodeScanner, setShowBarcodeScanner] = useState(false);
+  const handleChange = useCallback((field: keyof typeof formData, value: string) => {
+    setFormData((prev) => ({ ...prev, [field]: value }));
+  }, []);
   const handleBarcodeDetected = useCallback((code: string) => {
     handleChange('sample_id', code);
     setShowBarcodeScanner(false);
-  }, []);
+  }, [handleChange]);
   const { isSupported: barcodeSupported, isScanning, error: barcodeError, videoRef, startScan, stopScan } = useBarcode({
     onDetected: handleBarcodeDetected,
   });
@@ -81,10 +84,6 @@ export const SampleCreateModal = ({ isOpen, onClose, onSuccess }: SampleCreateMo
     } finally {
       setLoading(false);
     }
-  };
-
-  const handleChange = (field: keyof typeof formData, value: string) => {
-    setFormData((prev) => ({ ...prev, [field]: value }));
   };
 
   if (!isOpen) return null;

--- a/frontend/src/hooks/useEntityList.ts
+++ b/frontend/src/hooks/useEntityList.ts
@@ -27,7 +27,11 @@ export function useEntityList<T>(
   const [error, setError] = useState('');
 
   const loadFnRef = useRef(fetchFn);
-  loadFnRef.current = fetchFn;
+  // Keep the ref pointing at the latest fetchFn without writing it during
+  // render (refs must only be mutated in effects/handlers).
+  useEffect(() => {
+    loadFnRef.current = fetchFn;
+  });
 
   const mountedRef = useRef(true);
   useEffect(() => {

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { Layout } from '../components/Layout/Layout';
 import { Card } from '../components/common/Card';
@@ -28,14 +28,7 @@ export const Profile = () => {
     return () => { mountedRef.current = false; };
   }, []);
 
-  useEffect(() => {
-    if (isForceChange) {
-      setIsChangingPassword(true);
-    }
-    fetchProfile();
-  }, [isForceChange]);
-
-  const fetchProfile = async () => {
+  const fetchProfile = useCallback(async () => {
     try {
       setLoading(true);
       const data = await getCurrentUser();
@@ -47,7 +40,14 @@ export const Profile = () => {
     } finally {
       if (mountedRef.current) setLoading(false);
     }
-  };
+  }, []);
+
+  useEffect(() => {
+    if (isForceChange) {
+      setIsChangingPassword(true);
+    }
+    fetchProfile();
+  }, [isForceChange, fetchProfile]);
 
   if (loading) {
     return (


### PR DESCRIPTION
Addresses the advisory lint warnings by **fixing the genuine issues** and clearly scoping the rest.

### Fixed (real code smells / near-bugs)
- **useEntityList.ts** — `react-hooks/refs`: ref written during render → moved into an effect.
- **Profile.tsx** — `react-hooks/immutability`: `fetchProfile` called before declaration → hoisted as `useCallback` + added to deps.
- **SampleCreateModal.tsx** — `immutability` + `exhaustive-deps`: `handleChange` used before declaration → hoisted as `useCallback` + added to callback deps.

**18 → 14 warnings, 0 errors.** Behaviour-preserving: build ✓, vitest 46/46 ✓, Playwright e2e 7/7 ✓.

### Kept as accepted advisory (rule stays `warn`)
- `react-hooks/set-state-in-effect` (12) — modal-reset-on-close / data-load effects; a real fix means deriving state / keying components / parent-unmount = a refactor with behaviour risk on a released 1.0.
- `react-refresh/only-export-components` (2) — context provider+hook co-location; HMR-dev-only rule, no runtime impact, splitting would churn 11 imports for no benefit.

https://claude.ai/code/session_01QwRSUQRhHR4mkfvvaoqnYJ