### PR TITLE
feat(ux): UX overhaul — design tokens, a11y, feedback, safety, navigation

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import { AuthProvider } from './context/AuthContext';
 import { ThemeProvider } from './context/ThemeContext';
+import { ToastProvider } from './components/common/Toast';
 import { ErrorBoundary } from './components/common/ErrorBoundary';
 import { ProtectedRoute } from './components/Auth/ProtectedRoute';
 import Login from './pages/Login';
@@ -17,6 +18,7 @@ function App() {
   return (
     <ErrorBoundary>
       <ThemeProvider>
+        <ToastProvider>
         <AuthProvider>
           <BrowserRouter>
           <Routes>
@@ -89,6 +91,7 @@ function App() {
           </Routes>
           </BrowserRouter>
         </AuthProvider>
+        </ToastProvider>
       </ThemeProvider>
     </ErrorBoundary>
   );

--- a/frontend/src/components/Layout/Header.tsx
+++ b/frontend/src/components/Layout/Header.tsx
@@ -52,7 +52,7 @@ export const Header = () => {
     <header className="h-16 bg-white border-b border-gray-200 flex items-center justify-between px-8">
       {/* Breadcrumbs - Industrial Wayfinding */}
       <div className="flex items-center text-sm font-medium text-gray-500 font-mono">
-        <Link to="/" className="hover:text-[#2563EB] transition-colors">
+        <Link to="/" className="hover:text-[#0055FF] transition-colors">
           <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
           </svg>
@@ -65,7 +65,7 @@ export const Header = () => {
       {/* Right Side: Search + Logout */}
       <div className="flex items-center space-x-4">
         {/* Search Bar */}
-        <div className="flex items-center border border-gray-300 rounded-sm px-3 py-1.5 w-64 gap-2 focus-within:border-[#2563EB] focus-within:ring-1 focus-within:ring-[#2563EB] bg-white">
+        <div className="flex items-center border border-gray-300 rounded-sm px-3 py-1.5 w-64 gap-2 focus-within:border-[#0055FF] focus-within:ring-1 focus-within:ring-[#0055FF] bg-white">
           <svg className="h-4 w-4 text-gray-400 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
           </svg>

--- a/frontend/src/components/Layout/Header.tsx
+++ b/frontend/src/components/Layout/Header.tsx
@@ -43,6 +43,7 @@ export const Header = () => {
       '/audit-log': 'Audit Log',
       '/users': 'Users',
       '/profile': 'Profile',
+      '/import': 'Import',
     };
 
     return routeNames[path] || 'Dashboard';

--- a/frontend/src/components/Layout/Layout.tsx
+++ b/frontend/src/components/Layout/Layout.tsx
@@ -9,10 +9,16 @@ interface LayoutProps {
 export const Layout = ({ children }: LayoutProps) => {
   return (
     <div className="min-h-screen bg-[#F4F5F7]">
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:absolute focus:z-[200] focus:top-2 focus:left-2 focus:bg-white focus:text-[#0055FF] focus:px-4 focus:py-2 focus:rounded focus:shadow-md focus:ring-2 focus:ring-[#0055FF]"
+      >
+        Skip to content
+      </a>
       <Sidebar />
       <div className="ml-64 flex flex-col min-h-screen">
         <Header />
-        <main className="flex-1 p-6 lg:p-8 page-transition">
+        <main id="main-content" tabIndex={-1} className="flex-1 p-6 lg:p-8 page-transition">
           {children}
         </main>
       </div>

--- a/frontend/src/components/Layout/Sidebar.tsx
+++ b/frontend/src/components/Layout/Sidebar.tsx
@@ -132,6 +132,7 @@ export const Sidebar = () => {
           <Link
             key={item.path}
             to={item.path}
+            aria-current={isActive(item.path) ? 'page' : undefined}
             className={`group flex items-center px-5 py-3 text-sm font-medium transition-colors border-l-4 ${
               isActive(item.path)
                 ? 'text-white bg-gray-800 border-[#0055FF]'
@@ -165,6 +166,7 @@ export const Sidebar = () => {
           <Link
             key={item.path}
             to={item.path}
+            aria-current={isActive(item.path) ? 'page' : undefined}
             className={`group flex items-center px-5 py-3 text-sm font-medium transition-colors border-l-4 ${
               isActive(item.path)
                 ? 'text-white bg-gray-800 border-[#0055FF]'

--- a/frontend/src/components/Layout/Sidebar.tsx
+++ b/frontend/src/components/Layout/Sidebar.tsx
@@ -121,7 +121,7 @@ export const Sidebar = () => {
           OpenSylab
         </span>
         {/* Version */}
-        <span className="mt-1 px-1.5 py-0.5 rounded text-[10px] font-mono font-bold bg-[#2563EB]/20 text-[#3B82F6] border border-[#2563EB]/30 uppercase tracking-wide">
+        <span className="mt-1 px-1.5 py-0.5 rounded text-[10px] font-mono font-bold bg-[#0055FF]/20 text-[#3B82F6] border border-[#0055FF]/30 uppercase tracking-wide">
           v{import.meta.env.VITE_APP_VERSION}
         </span>
       </div>
@@ -134,14 +134,14 @@ export const Sidebar = () => {
             to={item.path}
             className={`group flex items-center px-5 py-3 text-sm font-medium transition-colors border-l-4 ${
               isActive(item.path)
-                ? 'text-white bg-gray-800 border-[#2563EB]'
+                ? 'text-white bg-gray-800 border-[#0055FF]'
                 : 'text-gray-400 hover:text-white hover:bg-gray-800 border-transparent'
             }`}
           >
             <span
               className={`mr-3 ${
                 isActive(item.path)
-                  ? 'text-[#2563EB]'
+                  ? 'text-[#0055FF]'
                   : 'text-gray-500 group-hover:text-white transition-colors'
               }`}
             >
@@ -167,14 +167,14 @@ export const Sidebar = () => {
             to={item.path}
             className={`group flex items-center px-5 py-3 text-sm font-medium transition-colors border-l-4 ${
               isActive(item.path)
-                ? 'text-white bg-gray-800 border-[#2563EB]'
+                ? 'text-white bg-gray-800 border-[#0055FF]'
                 : 'text-gray-400 hover:text-white hover:bg-gray-800 border-transparent'
             }`}
           >
             <span
               className={`mr-3 ${
                 isActive(item.path)
-                  ? 'text-[#2563EB]'
+                  ? 'text-[#0055FF]'
                   : 'text-gray-500 group-hover:text-white transition-colors'
               }`}
             >

--- a/frontend/src/components/Orders/OrderCreateModal.tsx
+++ b/frontend/src/components/Orders/OrderCreateModal.tsx
@@ -93,7 +93,7 @@ export const OrderCreateModal = ({ isOpen, onClose, onSuccess }: OrderCreateModa
   const canSubmit = !loading && formData.order_id && formData.sample_id && formData.test_type && formData.requested_by;
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50 animate-backdrop">
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50 animate-backdrop">
       <div className="bg-white rounded shadow-xl max-w-2xl w-full max-h-[90vh] overflow-y-auto animate-snap-in">
         <div className="p-6">
           <div className="flex justify-between items-center mb-6">

--- a/frontend/src/components/Orders/OrderEditModal.tsx
+++ b/frontend/src/components/Orders/OrderEditModal.tsx
@@ -100,7 +100,7 @@ export const OrderEditModal = ({ isOpen, orderId, onClose, onSuccess }: OrderEdi
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50 animate-backdrop">
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50 animate-backdrop">
       <div className="bg-white rounded shadow-xl max-w-2xl w-full max-h-[90vh] overflow-y-auto animate-slide-top">
         <div className="p-6">
           <div className="flex justify-between items-center mb-6">

--- a/frontend/src/components/Results/ResultCreateModal.tsx
+++ b/frontend/src/components/Results/ResultCreateModal.tsx
@@ -126,7 +126,7 @@ export const ResultCreateModal = ({ isOpen, onClose, onSuccess }: ResultCreateMo
     ((!isNaN(refMinNum) && valueNum < refMinNum) || (!isNaN(refMaxNum) && valueNum > refMaxNum));
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50 animate-backdrop">
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50 animate-backdrop">
       <div className="bg-white rounded shadow-xl max-w-3xl w-full max-h-[90vh] overflow-y-auto">
         <div className="p-6">
           <div className="flex justify-between items-center mb-6">

--- a/frontend/src/components/Results/ResultCreateModal.tsx
+++ b/frontend/src/components/Results/ResultCreateModal.tsx
@@ -7,26 +7,12 @@ import { getOrders } from '../../services/orders';
 import type { TestResult } from '../../types/result';
 import type { Order } from '../../types/order';
 import { RESULT_STATUSES, RESULT_FLAGS, RESULT_FLAG_COLORS } from '../../utils/constants';
+import { computeFlag } from '../../utils/resultFlag';
 
 interface ResultCreateModalProps {
   isOpen: boolean;
   onClose: () => void;
   onSuccess?: (result: TestResult) => void;
-}
-
-function computeFlag(value: string, refMin: string, refMax: string): TestResult['flag'] {
-  const v = parseFloat(value);
-  if (isNaN(v)) return 'UNDEFINED';
-  const min = parseFloat(refMin);
-  const max = parseFloat(refMax);
-  if (isNaN(min) || isNaN(max) || min >= max) return 'UNDEFINED';
-  const margin = (max - min) * 0.5;
-  const criticalLow = min - margin;
-  const criticalHigh = max + margin;
-  if (v < criticalLow || v > criticalHigh) return 'CRITICAL';
-  if (v < min) return 'LOW';
-  if (v > max) return 'HIGH';
-  return 'NORMAL';
 }
 
 export const ResultCreateModal = ({ isOpen, onClose, onSuccess }: ResultCreateModalProps) => {
@@ -210,7 +196,7 @@ export const ResultCreateModal = ({ isOpen, onClose, onSuccess }: ResultCreateMo
                   <input
                     type="text"
                     placeholder="e.g., 95"
-                    value={formData.value}
+                    value={formData.value} inputMode="decimal"
                     onChange={(e) => handleChange('value', e.target.value)}
                     required
                     className={`w-full px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-[#0055FF] focus:border-transparent ${
@@ -241,14 +227,14 @@ export const ResultCreateModal = ({ isOpen, onClose, onSuccess }: ResultCreateMo
                   type="text"
                   label="Min Value"
                   placeholder="e.g., 70"
-                  value={formData.reference_min}
+                  value={formData.reference_min} inputMode="decimal"
                   onChange={(e) => handleChange('reference_min', e.target.value)}
                 />
                 <Input
                   type="text"
                   label="Max Value"
                   placeholder="e.g., 110"
-                  value={formData.reference_max}
+                  value={formData.reference_max} inputMode="decimal"
                   onChange={(e) => handleChange('reference_max', e.target.value)}
                 />
               </div>

--- a/frontend/src/components/Results/ResultEditModal.tsx
+++ b/frontend/src/components/Results/ResultEditModal.tsx
@@ -91,7 +91,7 @@ export const ResultEditModal = ({ isOpen, onClose, result, onSuccess }: ResultEd
 
   if (result.status === 'VALIDATED' || result.status === 'REJECTED') {
     return (
-      <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
+      <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50">
         <div className="bg-white rounded shadow-xl max-w-md w-full p-6">
           <div className="flex justify-between items-center mb-4">
             <h2 className="text-xl font-bold text-gray-900">Edit Test Result</h2>
@@ -113,7 +113,7 @@ export const ResultEditModal = ({ isOpen, onClose, result, onSuccess }: ResultEd
   }
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50 animate-backdrop">
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50 animate-backdrop">
       <div className="bg-white rounded shadow-xl max-w-3xl w-full max-h-[90vh] overflow-y-auto">
         <div className="p-6">
           <div className="flex justify-between items-center mb-6">

--- a/frontend/src/components/Results/ResultEditModal.tsx
+++ b/frontend/src/components/Results/ResultEditModal.tsx
@@ -5,6 +5,7 @@ import { Button } from '../common/Button';
 import { updateResult } from '../../services/results';
 import type { TestResult } from '../../types/result';
 import { RESULT_STATUSES, RESULT_FLAGS, RESULT_TRANSITIONS } from '../../utils/constants';
+import { computeFlag } from '../../utils/resultFlag';
 
 interface ResultEditModalProps {
   isOpen: boolean;
@@ -29,6 +30,7 @@ export const ResultEditModal = ({ isOpen, onClose, result, onSuccess }: ResultEd
   });
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
+  const [flagManuallySet, setFlagManuallySet] = useState(false);
 
   useEffect(() => {
     if (!isOpen || !result) return;
@@ -45,7 +47,22 @@ export const ResultEditModal = ({ isOpen, onClose, result, onSuccess }: ResultEd
       reviewed_by: result.reviewed_by || '',
       notes: result.notes || '',
     });
+    setFlagManuallySet(false);
   }, [isOpen, result]);
+
+  // Keep the flag consistent with the value/range on edit (unless the user has
+  // manually overridden it) — a corrected value must not keep a stale flag.
+  useEffect(() => {
+    if (!formData.value || flagManuallySet) return;
+    const autoFlag = computeFlag(
+      formData.value,
+      formData.reference_min,
+      formData.reference_max
+    );
+    setFormData((prev) =>
+      prev.flag === autoFlag ? prev : { ...prev, flag: autoFlag }
+    );
+  }, [formData.value, formData.reference_min, formData.reference_max, flagManuallySet]);
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
@@ -80,6 +97,7 @@ export const ResultEditModal = ({ isOpen, onClose, result, onSuccess }: ResultEd
   };
 
   const handleChange = (field: keyof typeof formData, value: string) => {
+    if (field === 'flag') setFlagManuallySet(true);
     setFormData((prev) => ({ ...prev, [field]: value }));
   };
 
@@ -148,7 +166,7 @@ export const ResultEditModal = ({ isOpen, onClose, result, onSuccess }: ResultEd
               <h3 className="text-lg font-semibold text-gray-900 mb-3">Test Parameters</h3>
               <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
                 <Input type="text" label="Parameter *" value={formData.parameter} onChange={(e) => handleChange('parameter', e.target.value)} required />
-                <Input type="text" label="Value *" value={formData.value} onChange={(e) => handleChange('value', e.target.value)} required />
+                <Input type="text" label="Value *" inputMode="decimal" value={formData.value} onChange={(e) => handleChange('value', e.target.value)} required />
                 <Input type="text" label="Unit" value={formData.unit} onChange={(e) => handleChange('unit', e.target.value)} />
               </div>
             </div>
@@ -156,8 +174,8 @@ export const ResultEditModal = ({ isOpen, onClose, result, onSuccess }: ResultEd
             <div className="border-b border-gray-200 pb-4">
               <h3 className="text-lg font-semibold text-gray-900 mb-3">Reference Range</h3>
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                <Input type="text" label="Min Value" value={formData.reference_min} onChange={(e) => handleChange('reference_min', e.target.value)} />
-                <Input type="text" label="Max Value" value={formData.reference_max} onChange={(e) => handleChange('reference_max', e.target.value)} />
+                <Input type="text" label="Min Value" inputMode="decimal" value={formData.reference_min} onChange={(e) => handleChange('reference_min', e.target.value)} />
+                <Input type="text" label="Max Value" inputMode="decimal" value={formData.reference_max} onChange={(e) => handleChange('reference_max', e.target.value)} />
               </div>
             </div>
 

--- a/frontend/src/components/Samples/SampleCreateModal.tsx
+++ b/frontend/src/components/Samples/SampleCreateModal.tsx
@@ -89,7 +89,7 @@ export const SampleCreateModal = ({ isOpen, onClose, onSuccess }: SampleCreateMo
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50 animate-backdrop">
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50 animate-backdrop">
       <div className="bg-white rounded shadow-xl max-w-2xl w-full max-h-[90vh] overflow-y-auto animate-snap-in">
         <div className="p-6">
           <div className="flex justify-between items-center mb-6">
@@ -199,7 +199,7 @@ export const SampleCreateModal = ({ isOpen, onClose, onSuccess }: SampleCreateMo
             </div>
 
             {showBarcodeScanner && (
-              <div className="fixed inset-0 bg-black bg-opacity-75 z-60 flex flex-col items-center justify-center p-4">
+              <div className="fixed inset-0 bg-black/75 z-60 flex flex-col items-center justify-center p-4">
                 <div className="bg-black rounded-lg overflow-hidden w-full max-w-sm">
                   <div className="p-4 flex justify-between items-center bg-gray-900">
                     <span className="text-white text-sm font-medium">Barcode scannen</span>

--- a/frontend/src/components/Samples/SampleEditModal.tsx
+++ b/frontend/src/components/Samples/SampleEditModal.tsx
@@ -96,7 +96,7 @@ export const SampleEditModal = ({ isOpen, sampleId, onClose, onSuccess }: Sample
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50 animate-backdrop">
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50 animate-backdrop">
       <div className="bg-white rounded shadow-xl max-w-2xl w-full max-h-[90vh] overflow-y-auto animate-slide-top">
         <div className="p-6">
           <div className="flex justify-between items-center mb-6">

--- a/frontend/src/components/common/Button.tsx
+++ b/frontend/src/components/common/Button.tsx
@@ -16,7 +16,7 @@ export const Button = ({
   const baseStyles = 'font-medium rounded-sm transition-all duration-150 ease-out focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center';
 
   const variantStyles = {
-    primary: 'bg-[#2563EB] hover:bg-[#1d4ed8] text-white focus:ring-[#2563EB] shadow-sm',
+    primary: 'bg-[#0055FF] hover:bg-[#1d4ed8] text-white focus:ring-[#0055FF] shadow-sm',
     secondary: 'bg-white hover:bg-gray-50 text-gray-700 border border-gray-300 focus:ring-gray-500',
     danger: 'bg-red-600 hover:bg-red-700 text-white focus:ring-red-500 shadow-sm',
     ghost: 'bg-transparent text-gray-400 hover:text-red-600 hover:bg-red-50 focus:ring-red-500 transition-colors',

--- a/frontend/src/components/common/DeleteConfirmDialog.tsx
+++ b/frontend/src/components/common/DeleteConfirmDialog.tsx
@@ -1,5 +1,6 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useId, useRef } from 'react';
 import { Button } from './Button';
+import { useModalA11y } from '../../hooks/useModalA11y';
 
 interface DeleteConfirmDialogProps {
   isOpen: boolean;
@@ -10,19 +11,22 @@ interface DeleteConfirmDialogProps {
   itemName?: string;
   confirmText?: string;
   cancelText?: string;
+  /** Accurate description of what happens (most deletes are soft-deletes). */
+  outcomeNote?: string;
 }
 
 /**
- * Reusable delete confirmation dialog component
+ * Reusable delete confirmation dialog component.
  *
  * @example
  * <DeleteConfirmDialog
  *   isOpen={showDeleteDialog}
  *   onClose={() => setShowDeleteDialog(false)}
  *   onConfirm={handleDeleteSample}
- *   title="Delete Sample"
- *   message="Are you sure you want to delete this sample?"
+ *   title="Archive Sample"
+ *   message="Archive this sample?"
  *   itemName={sample.sample_id}
+ *   outcomeNote="The sample is marked ARCHIVED and hidden from active lists. Audit history is retained."
  * />
  */
 export const DeleteConfirmDialog = ({
@@ -34,10 +38,14 @@ export const DeleteConfirmDialog = ({
   itemName,
   confirmText = 'Delete',
   cancelText = 'Cancel',
+  outcomeNote = 'This action is recorded in the audit trail.',
 }: DeleteConfirmDialogProps) => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const titleId = useId();
   useEffect(() => { if (!isOpen) setError(''); }, [isOpen]);
+  useModalA11y(isOpen, onClose, dialogRef, { disableClose: loading });
 
   const handleConfirm = async () => {
     setError('');
@@ -66,8 +74,18 @@ export const DeleteConfirmDialog = ({
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50">
-      <div className="bg-white rounded shadow-xl max-w-md w-full">
+    <div
+      className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50"
+      onMouseDown={(e) => { if (e.target === e.currentTarget && !loading) onClose(); }}
+    >
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        tabIndex={-1}
+        className="bg-white dark:bg-dark-surface rounded shadow-xl max-w-md w-full focus:outline-none"
+      >
         <div className="p-6">
           {/* Header with warning icon */}
           <div className="flex items-start mb-4">
@@ -81,38 +99,37 @@ export const DeleteConfirmDialog = ({
                   strokeWidth="2"
                   viewBox="0 0 24 24"
                   stroke="currentColor"
+                  aria-hidden="true"
                 >
                   <path d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
                 </svg>
               </div>
             </div>
             <div className="ml-4 flex-1">
-              <h3 className="text-lg font-semibold text-gray-900 mb-2">
+              <h3 id={titleId} className="text-lg font-semibold text-gray-900 dark:text-white mb-2">
                 {title}
               </h3>
-              <div className="text-sm text-gray-600 space-y-2">
+              <div className="text-sm text-gray-600 dark:text-gray-300 space-y-2">
                 <p>{message}</p>
                 {itemName && (
-                  <p className="font-medium text-gray-900">
-                    Item: <span className="text-red-600">{itemName}</span>
+                  <p className="font-medium text-gray-900 dark:text-white">
+                    Item: <span className="text-red-600 dark:text-red-400 font-mono">{itemName}</span>
                   </p>
                 )}
-                <p className="text-red-600 font-medium">
-                  This action cannot be undone.
-                </p>
+                <p className="text-gray-500 dark:text-gray-400">{outcomeNote}</p>
               </div>
             </div>
           </div>
 
           {/* Error message */}
           {error && (
-            <div className="mb-4 bg-red-50 border border-red-200 rounded p-3">
+            <div className="mb-4 bg-red-50 border border-red-200 rounded p-3" role="alert">
               <p className="text-red-800 text-sm">{error}</p>
             </div>
           )}
 
           {/* Action buttons */}
-          <div className="flex justify-end gap-3 pt-4 border-t border-gray-200">
+          <div className="flex justify-end gap-3 pt-4 border-t border-gray-200 dark:border-white/10">
             <Button
               type="button"
               variant="secondary"
@@ -127,7 +144,7 @@ export const DeleteConfirmDialog = ({
               onClick={handleConfirm}
               disabled={loading}
             >
-              {loading ? 'Deleting...' : confirmText}
+              {loading ? 'Working…' : confirmText}
             </Button>
           </div>
         </div>

--- a/frontend/src/components/common/DeleteConfirmDialog.tsx
+++ b/frontend/src/components/common/DeleteConfirmDialog.tsx
@@ -66,7 +66,7 @@ export const DeleteConfirmDialog = ({
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50">
       <div className="bg-white rounded shadow-xl max-w-md w-full">
         <div className="p-6">
           {/* Header with warning icon */}

--- a/frontend/src/components/common/ErrorBanner.tsx
+++ b/frontend/src/components/common/ErrorBanner.tsx
@@ -1,22 +1,36 @@
 interface ErrorBannerProps {
   message: string | null;
   onDismiss?: () => void;
+  onRetry?: () => void;
 }
 
-export const ErrorBanner = ({ message, onDismiss }: ErrorBannerProps) => {
+export const ErrorBanner = ({ message, onDismiss, onRetry }: ErrorBannerProps) => {
   if (!message) return null;
   return (
-    <div className="bg-red-50 dark:bg-red-950 border border-red-200 dark:border-red-800 rounded p-4 flex justify-between items-start">
+    <div
+      role="alert"
+      className="bg-red-50 dark:bg-red-950 border border-red-200 dark:border-red-800 rounded p-4 flex justify-between items-start gap-4"
+    >
       <p className="text-red-800 dark:text-red-200 text-sm">{message}</p>
-      {onDismiss && (
-        <button
-          onClick={onDismiss}
-          className="ml-4 text-red-500 hover:text-red-700 dark:hover:text-red-300 text-lg leading-none"
-          aria-label="Dismiss error"
-        >
-          ×
-        </button>
-      )}
+      <div className="flex items-center gap-3 shrink-0">
+        {onRetry && (
+          <button
+            onClick={onRetry}
+            className="text-sm font-medium text-red-700 dark:text-red-300 underline hover:no-underline focus:outline-none focus-visible:ring-2 focus-visible:ring-[#0055FF] rounded"
+          >
+            Retry
+          </button>
+        )}
+        {onDismiss && (
+          <button
+            onClick={onDismiss}
+            className="text-red-500 hover:text-red-700 dark:hover:text-red-300 text-lg leading-none focus:outline-none focus-visible:ring-2 focus-visible:ring-[#0055FF] rounded"
+            aria-label="Dismiss error"
+          >
+            ×
+          </button>
+        )}
+      </div>
     </div>
   );
 };

--- a/frontend/src/components/common/Input.tsx
+++ b/frontend/src/components/common/Input.tsx
@@ -1,4 +1,4 @@
-import { forwardRef } from 'react';
+import { forwardRef, useId } from 'react';
 import type { InputHTMLAttributes } from 'react';
 
 interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
@@ -7,23 +7,39 @@ interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
 }
 
 export const Input = forwardRef<HTMLInputElement, InputProps>(
-  ({ label, error, className = '', ...props }, ref) => {
+  ({ label, error, className = '', id, required, ...props }, ref) => {
+    const generatedId = useId();
+    const inputId = id ?? generatedId;
+    const errorId = `${inputId}-error`;
     return (
       <div className="w-full">
         {label && (
-          <label className="block text-sm font-medium text-gray-700 mb-1">
+          <label
+            htmlFor={inputId}
+            className="block text-sm font-medium text-gray-700 mb-1"
+          >
             {label}
+            {required && (
+              <span className="text-red-600 ml-0.5" aria-hidden="true">
+                *
+              </span>
+            )}
           </label>
         )}
         <input
           ref={ref}
-          className={`w-full px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent ${
+          id={inputId}
+          required={required}
+          aria-required={required || undefined}
+          aria-invalid={error ? true : undefined}
+          aria-describedby={error ? errorId : undefined}
+          className={`w-full px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-[#0055FF] focus:border-transparent ${
             error ? 'border-red-500' : 'border-gray-300'
           } ${className}`}
           {...props}
         />
         {error && (
-          <p className="mt-1 text-sm text-red-600" role="alert">
+          <p id={errorId} className="mt-1 text-sm text-red-600" role="alert">
             {error}
           </p>
         )}

--- a/frontend/src/components/common/Toast.tsx
+++ b/frontend/src/components/common/Toast.tsx
@@ -1,4 +1,4 @@
-import { createContext, useCallback, useEffect, useRef, useState } from 'react';
+import { createContext, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
 
 export type ToastKind = 'success' | 'error' | 'info';
@@ -45,15 +45,16 @@ export const ToastProvider = ({ children }: { children: ReactNode }) => {
     [dismiss]
   );
 
-  const apiRef = useRef<ToastApi>({
-    success: (m) => push('success', m),
-    error: (m) => push('error', m),
-    info: (m) => push('info', m),
-  });
-  // Keep the closures current without changing the stable object identity.
-  apiRef.current.success = (m) => push('success', m);
-  apiRef.current.error = (m) => push('error', m);
-  apiRef.current.info = (m) => push('info', m);
+  // push is stable (useCallback over the stable dismiss), so the api object is
+  // built once and never needs re-mutation during render.
+  const api = useMemo<ToastApi>(
+    () => ({
+      success: (m) => push('success', m),
+      error: (m) => push('error', m),
+      info: (m) => push('info', m),
+    }),
+    [push]
+  );
 
   useEffect(() => {
     const pending = timers.current;
@@ -69,7 +70,7 @@ export const ToastProvider = ({ children }: { children: ReactNode }) => {
   };
 
   return (
-    <ToastContext.Provider value={apiRef.current}>
+    <ToastContext.Provider value={api}>
       {children}
       <div
         role="status"

--- a/frontend/src/components/common/Toast.tsx
+++ b/frontend/src/components/common/Toast.tsx
@@ -1,0 +1,97 @@
+import { createContext, useCallback, useEffect, useRef, useState } from 'react';
+import type { ReactNode } from 'react';
+
+export type ToastKind = 'success' | 'error' | 'info';
+
+interface Toast {
+  id: number;
+  kind: ToastKind;
+  message: string;
+}
+
+interface ToastApi {
+  success: (message: string) => void;
+  error: (message: string) => void;
+  info: (message: string) => void;
+}
+
+// eslint-disable-next-line react-refresh/only-export-components
+export const ToastContext = createContext<ToastApi | null>(null);
+
+const AUTO_DISMISS_MS = 4000;
+
+// Rectangular, sparing, "device-like" toasts per DESIGN.md — a small stack in the
+// bottom-right. role="status" + aria-live so screen readers announce write results.
+export const ToastProvider = ({ children }: { children: ReactNode }) => {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+  const nextId = useRef(1);
+  const timers = useRef<Record<number, ReturnType<typeof setTimeout>>>({});
+
+  const dismiss = useCallback((id: number) => {
+    setToasts((list) => list.filter((t) => t.id !== id));
+    const timer = timers.current[id];
+    if (timer) {
+      clearTimeout(timer);
+      delete timers.current[id];
+    }
+  }, []);
+
+  const push = useCallback(
+    (kind: ToastKind, message: string) => {
+      const id = nextId.current++;
+      setToasts((list) => [...list, { id, kind, message }]);
+      timers.current[id] = setTimeout(() => dismiss(id), AUTO_DISMISS_MS);
+    },
+    [dismiss]
+  );
+
+  const apiRef = useRef<ToastApi>({
+    success: (m) => push('success', m),
+    error: (m) => push('error', m),
+    info: (m) => push('info', m),
+  });
+  // Keep the closures current without changing the stable object identity.
+  apiRef.current.success = (m) => push('success', m);
+  apiRef.current.error = (m) => push('error', m);
+  apiRef.current.info = (m) => push('info', m);
+
+  useEffect(() => {
+    const pending = timers.current;
+    return () => {
+      Object.values(pending).forEach(clearTimeout);
+    };
+  }, []);
+
+  const kindClass: Record<ToastKind, string> = {
+    success: 'border-l-[#10B981] text-clinical-text',
+    error: 'border-l-[#FF3B30] text-clinical-text',
+    info: 'border-l-[#0055FF] text-clinical-text',
+  };
+
+  return (
+    <ToastContext.Provider value={apiRef.current}>
+      {children}
+      <div
+        role="status"
+        aria-live="polite"
+        className="fixed bottom-4 right-4 z-[100] flex flex-col gap-2 w-80 max-w-[calc(100vw-2rem)]"
+      >
+        {toasts.map((t) => (
+          <div
+            key={t.id}
+            className={`flex items-start justify-between gap-3 bg-white dark:bg-dark-surface border border-clinical-border dark:border-white/10 border-l-4 ${kindClass[t.kind]} dark:text-white rounded px-4 py-3 shadow-sm animate-snap-in`}
+          >
+            <span className="text-sm">{t.message}</span>
+            <button
+              onClick={() => dismiss(t.id)}
+              aria-label="Dismiss notification"
+              className="text-lg leading-none text-clinical-secondary hover:text-clinical-text dark:hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-[#0055FF] rounded"
+            >
+              ×
+            </button>
+          </div>
+        ))}
+      </div>
+    </ToastContext.Provider>
+  );
+};

--- a/frontend/src/hooks/useModalA11y.ts
+++ b/frontend/src/hooks/useModalA11y.ts
@@ -1,0 +1,81 @@
+import { useEffect, useRef } from 'react';
+import type { RefObject } from 'react';
+
+const FOCUSABLE =
+  'a[href],button:not([disabled]),textarea:not([disabled]),input:not([disabled]),select:not([disabled]),[tabindex]:not([tabindex="-1"])';
+
+/**
+ * Accessibility behaviour for a modal dialog, applied to the dialog container ref:
+ * - moves focus into the dialog on open (first focusable, else the container)
+ * - traps Tab / Shift+Tab within the dialog
+ * - closes on Escape
+ * - restores focus to the previously-focused element on close
+ * - locks body scroll while open
+ *
+ * The caller keeps its own markup; it only needs to attach `ref` to the dialog
+ * container and set role="dialog" aria-modal="true" aria-labelledby={...}.
+ */
+export function useModalA11y(
+  isOpen: boolean,
+  onClose: () => void,
+  dialogRef: RefObject<HTMLElement | null>,
+  options: { disableClose?: boolean } = {}
+) {
+  const disableClose = options.disableClose ?? false;
+  // Keep the latest onClose/disableClose without re-running the open effect.
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+  const disableCloseRef = useRef(disableClose);
+  disableCloseRef.current = disableClose;
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const node = dialogRef.current;
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+
+    const focusables = (): HTMLElement[] =>
+      node
+        ? Array.from(node.querySelectorAll<HTMLElement>(FOCUSABLE)).filter(
+            (el) => el.offsetParent !== null || el === document.activeElement
+          )
+        : [];
+
+    (focusables()[0] ?? node)?.focus();
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        if (!disableCloseRef.current) {
+          e.stopPropagation();
+          onCloseRef.current();
+        }
+        return;
+      }
+      if (e.key !== 'Tab') return;
+      const els = focusables();
+      if (els.length === 0) {
+        e.preventDefault();
+        node?.focus();
+        return;
+      }
+      const first = els[0];
+      const last = els[els.length - 1];
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener('keydown', onKeyDown, true);
+    const prevOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+
+    return () => {
+      document.removeEventListener('keydown', onKeyDown, true);
+      document.body.style.overflow = prevOverflow;
+      previouslyFocused?.focus?.();
+    };
+  }, [isOpen, dialogRef]);
+}

--- a/frontend/src/hooks/useToast.ts
+++ b/frontend/src/hooks/useToast.ts
@@ -1,0 +1,10 @@
+import { useContext } from 'react';
+import { ToastContext } from '../components/common/Toast';
+
+export const useToast = () => {
+  const ctx = useContext(ToastContext);
+  if (!ctx) {
+    throw new Error('useToast must be used within a ToastProvider');
+  }
+  return ctx;
+};

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -5,6 +5,36 @@
 
 @import "tailwindcss";
 
+/* --- Design tokens (Tailwind v4 @theme) ---------------------------------
+ * Tailwind v4 ignores tailwind.config.js unless pulled in explicitly, so the
+ * DESIGN.md "Sterile & Slate" palette is registered here as the single source
+ * of truth. This is what makes utilities like bg-clinical-surface,
+ * text-clinical-secondary and font-mono (JetBrains Mono) actually generate CSS. */
+@theme {
+  --color-clinical-bg: #F4F5F7;
+  --color-clinical-surface: #FFFFFF;
+  --color-clinical-text: #1A1C20;
+  --color-clinical-secondary: #5E6C84;
+  --color-clinical-border: #E2E8F0;
+  --color-clinical-hover: #FAFBFC;
+  --color-clinical-blue: #0055FF;   /* System Blue — the one primary action colour */
+  --color-clinical-green: #10B981;
+  --color-clinical-biohazard: #CCFF00;
+  --color-clinical-critical: #FF3B30;
+
+  --color-dark-bg: #0D0E12;
+  --color-dark-surface: #16181D;
+  --color-dark-text: #E0E0E0;
+
+  --font-sans: "Inter", system-ui, -apple-system, sans-serif;
+  --font-mono: "JetBrains Mono", "Roboto Mono", ui-monospace, monospace;
+}
+
+/* Data font aligns digits in columns (DESIGN.md §3 "Data is King"). */
+.font-mono {
+  font-variant-numeric: tabular-nums;
+}
+
 :root {
     /* Palette: Sterile & Slate */
     --bg-body: #F4F5F7;       /* Clinical Grey */
@@ -16,7 +46,7 @@
     --text-on-dark: #E5E7EB;
 
     --border-subtle: #E5E7EB;
-    --border-focus: #2563EB;  /* System Blue */
+    --border-focus: #0055FF;  /* System Blue */
 
     /* Semantic Colors */
     --status-blue-bg: #EFF6FF;
@@ -284,7 +314,7 @@ button.primary:hover {
 }
 
 /* 3. Primary Buttons: "Dangerous Competence" */
-.dark button[class*="bg-[#2563EB]"],
+.dark button[class*="bg-[#0055FF]"],
 .dark .btn-primary {
     background-color: var(--accent-acid) !important;
     color: #000000 !important;
@@ -297,7 +327,7 @@ button.primary:hover {
     transition: all 0.1s ease-in;
 }
 
-.dark button[class*="bg-[#2563EB]"]:hover,
+.dark button[class*="bg-[#0055FF]"]:hover,
 .dark .btn-primary:hover {
     background-color: #D4FF33 !important;
     box-shadow: 0 0 12px rgba(204, 255, 0, 0.4);
@@ -426,8 +456,9 @@ button.primary:hover {
 }
 
 /* 10. Modals */
-.dark [class*="bg-opacity-50"] {
-    background-color: rgba(3, 4, 7, 0.95) !important;
+.dark [class*="bg-black/50"],
+.dark [class*="bg-black/75"] {
+    background-color: rgba(3, 4, 7, 0.85) !important;
 }
 
 /* 11. Alert Boxes */

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
 import { Layout } from '../components/Layout/Layout';
 import { getDashboardStats } from '../services/stats';
 import { getSamples } from '../services/samples';
@@ -241,8 +242,11 @@ export const Dashboard = () => {
             )}
           </div>
 
-          {/* Critical Results Alert Kachel */}
-          <div className={`p-6 border transition-colors duration-150 ${
+          {/* Critical Results Alert Kachel — jumps to the filtered critical list */}
+          <Link
+            to="/results?flag=CRITICAL"
+            title="View critical results"
+            className={`block p-6 border transition-colors duration-150 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#0055FF] ${
             criticalCount > 0
               ? 'bg-red-50 border-red-300 hover:border-red-500'
               : 'bg-white border-[#E2E8F0] hover:border-[#0055FF]'
@@ -260,7 +264,7 @@ export const Dashboard = () => {
                 {criticalCount > 0 ? '⚠ CRITICAL results require immediate review' : 'No critical results'}
               </p>
             </div>
-          </div>
+          </Link>
         </div>
 
         {/* Charts Section */}

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -72,7 +72,6 @@ export const Login = () => {
                   placeholder="Enter your password"
                   value={password}
                   onChange={(e) => setPassword(e.target.value)}
-                  error={error}
                   required
                   autoComplete="current-password"
                   aria-label="Password"
@@ -90,7 +89,9 @@ export const Login = () => {
                   label="MFA Code"
                   placeholder="6-digit code"
                   value={mfaCode}
-                  onChange={(e) => setMfaCode(e.target.value)}
+                  onChange={(e) => setMfaCode(e.target.value.replace(/\D/g, ''))}
+                  inputMode="numeric"
+                  pattern="[0-9]*"
                   maxLength={6}
                   autoFocus
                   autoComplete="one-time-code"
@@ -100,7 +101,7 @@ export const Login = () => {
             )}
 
             {error && (
-              <p className="text-red-600 text-sm">{error}</p>
+              <p role="alert" className="text-red-600 text-sm">{error}</p>
             )}
 
             <Button

--- a/frontend/src/pages/Orders.tsx
+++ b/frontend/src/pages/Orders.tsx
@@ -160,7 +160,7 @@ export const Orders = () => {
             <ErrorBanner message={error || null} onRetry={error ? refetch : undefined} />
 
             {loading ? (
-              <div className="flex items-center justify-center py-12">
+              <div role="status" aria-live="polite" className="flex items-center justify-center py-12">
                 <div className="text-center">
                   <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto"></div>
                   <p className="mt-4 text-gray-600">Loading orders...</p>

--- a/frontend/src/pages/Orders.tsx
+++ b/frontend/src/pages/Orders.tsx
@@ -37,7 +37,6 @@ export const Orders = () => {
   const [selectedOrderId, setSelectedOrderId] = useState<string | null>(null);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const [orderToDelete, setOrderToDelete] = useState<Order | null>(null);
-  const [deleteError, setDeleteError] = useState<string | null>(null);
   const itemsPerPage = 20;
 
   const { data: orders, total: totalOrders, loading, error, refetch } = useEntityList(
@@ -79,18 +78,12 @@ export const Orders = () => {
     setIsDeleteDialogOpen(true);
   };
 
+  // Errors propagate to DeleteConfirmDialog (shown inline; dialog stays open).
   const handleDeleteConfirm = async () => {
     if (!orderToDelete) return;
-    setDeleteError(null);
-    try {
-      await deleteOrder(orderToDelete.order_id);
-      toast.success(`Order ${orderToDelete.order_id} cancelled`);
-      setIsDeleteDialogOpen(false);
-      setOrderToDelete(null);
-      refetch();
-    } catch (err) {
-      setDeleteError(err instanceof Error ? err.message : 'Delete failed');
-    }
+    await deleteOrder(orderToDelete.order_id);
+    toast.success(`Order ${orderToDelete.order_id} cancelled`);
+    refetch();
   };
 
   return (
@@ -164,7 +157,7 @@ export const Orders = () => {
               </div>
             </div>
 
-            <ErrorBanner message={deleteError || error || null} />
+            <ErrorBanner message={error || null} onRetry={error ? refetch : undefined} />
 
             {loading ? (
               <div className="flex items-center justify-center py-12">
@@ -413,12 +406,14 @@ export const Orders = () => {
         onClose={() => {
           setIsDeleteDialogOpen(false);
           setOrderToDelete(null);
-          setDeleteError(null);
         }}
         onConfirm={handleDeleteConfirm}
-        title="Delete Order"
-        message="Are you sure you want to delete this order? This will permanently remove all associated data."
+        title="Cancel Order"
+        message="Cancel this order?"
         itemName={orderToDelete?.order_id}
+        confirmText="Cancel Order"
+        cancelText="Keep"
+        outcomeNote="The order is marked CANCELLED (soft-delete). Its audit history is retained."
       />
     </Layout>
   );

--- a/frontend/src/pages/Orders.tsx
+++ b/frontend/src/pages/Orders.tsx
@@ -13,10 +13,12 @@ import { ORDER_STATUSES, ORDER_PRIORITIES } from '../utils/constants';
 import { useDocumentTitle } from '../hooks/useDocumentTitle';
 import { useAuth } from '../context/AuthContext';
 import { useEntityList } from '../hooks/useEntityList';
+import { useToast } from '../hooks/useToast';
 
 export const Orders = () => {
   useDocumentTitle({ module: 'Orders' });
   const { user } = useAuth();
+  const toast = useToast();
   const canWrite = user?.role === 'ADMIN' || user?.role === 'OPERATOR';
   const location = useLocation();
   const [searchQuery, setSearchQuery] = useState<string>('');
@@ -57,7 +59,8 @@ export const Orders = () => {
     window.scrollTo({ top: 0, behavior: 'smooth' });
   };
 
-  const handleCreateSuccess = (_newOrder: Order) => {
+  const handleCreateSuccess = (newOrder: Order) => {
+    toast.success(`Order ${newOrder.order_id} created`);
     refetch();
   };
 
@@ -66,7 +69,8 @@ export const Orders = () => {
     setIsEditModalOpen(true);
   };
 
-  const handleEditSuccess = (_updatedOrder: Order) => {
+  const handleEditSuccess = (updatedOrder: Order) => {
+    toast.success(`Order ${updatedOrder.order_id} updated`);
     refetch();
   };
 
@@ -80,6 +84,7 @@ export const Orders = () => {
     setDeleteError(null);
     try {
       await deleteOrder(orderToDelete.order_id);
+      toast.success(`Order ${orderToDelete.order_id} cancelled`);
       setIsDeleteDialogOpen(false);
       setOrderToDelete(null);
       refetch();

--- a/frontend/src/pages/Orders.tsx
+++ b/frontend/src/pages/Orders.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation, Link } from 'react-router-dom';
 import { Layout } from '../components/Layout/Layout';
 import { Card } from '../components/common/Card';
 import { Button } from '../components/common/Button';
@@ -208,8 +208,14 @@ export const Orders = () => {
                         <td className="px-3 md:px-6 py-2 md:py-2.5 whitespace-nowrap text-sm font-mono font-bold text-[#1A1C20] border-b border-[#E2E8F0]">
                           {order.order_id}
                         </td>
-                        <td className="px-3 md:px-6 py-2 md:py-2.5 whitespace-nowrap text-sm font-mono text-[#5E6C84] border-b border-[#E2E8F0]">
-                          {order.sample_id}
+                        <td className="px-3 md:px-6 py-2 md:py-2.5 whitespace-nowrap text-sm font-mono border-b border-[#E2E8F0]">
+                          <Link
+                            to={`/samples?q=${encodeURIComponent(order.sample_id)}`}
+                            className="text-[#0055FF] hover:underline"
+                            title={`View sample ${order.sample_id}`}
+                          >
+                            {order.sample_id}
+                          </Link>
                         </td>
                         <td className="px-3 md:px-6 py-2 md:py-2.5 whitespace-nowrap text-sm font-medium text-[#1A1C20] border-b border-[#E2E8F0]">
                           {order.test_type}

--- a/frontend/src/pages/Results.tsx
+++ b/frontend/src/pages/Results.tsx
@@ -13,10 +13,12 @@ import { RESULT_STATUSES, RESULT_FLAGS } from '../utils/constants';
 import { useDocumentTitle } from '../hooks/useDocumentTitle';
 import { useAuth } from '../context/AuthContext';
 import { useEntityList } from '../hooks/useEntityList';
+import { useToast } from '../hooks/useToast';
 
 export const Results = () => {
   useDocumentTitle({ module: 'Test Results' });
   const { user } = useAuth();
+  const toast = useToast();
   const canWrite = user?.role === 'ADMIN' || user?.role === 'OPERATOR';
   const location = useLocation();
   const [searchQuery, setSearchQuery] = useState<string>('');
@@ -69,7 +71,8 @@ export const Results = () => {
     window.scrollTo({ top: 0, behavior: 'smooth' });
   };
 
-  const handleCreateSuccess = (_newResult: TestResult) => {
+  const handleCreateSuccess = (newResult: TestResult) => {
+    toast.success(`Result ${newResult.result_id} created`);
     refetch();
   };
 
@@ -78,7 +81,8 @@ export const Results = () => {
     setIsEditModalOpen(true);
   };
 
-  const handleEditSuccess = (_updatedResult: TestResult) => {
+  const handleEditSuccess = (updatedResult: TestResult) => {
+    toast.success(`Result ${updatedResult.result_id} updated`);
     refetch();
   };
 
@@ -92,6 +96,7 @@ export const Results = () => {
     setDeleteError(null);
     try {
       await deleteResult(resultToDelete.result_id);
+      toast.success(`Result ${resultToDelete.result_id} rejected`);
       setIsDeleteDialogOpen(false);
       setResultToDelete(null);
       refetch();

--- a/frontend/src/pages/Results.tsx
+++ b/frontend/src/pages/Results.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation, Link } from 'react-router-dom';
 import { Layout } from '../components/Layout/Layout';
 import { Card } from '../components/common/Card';
 import { Button } from '../components/common/Button';
@@ -49,6 +49,8 @@ export const Results = () => {
   useEffect(() => {
     const params = new URLSearchParams(location.search);
     setSearchQuery(params.get('q') || '');
+    setSelectedFlag(params.get('flag') || '');
+    setSelectedStatus(params.get('status') || '');
     setCurrentPage(1);
   }, [location.search]);
 
@@ -202,7 +204,15 @@ export const Results = () => {
                         <td className="px-6 py-2.5 whitespace-nowrap text-sm font-mono font-bold text-[#1A1C20] border-b border-[#E2E8F0]">
                           {result.result_id}
                         </td>
-                        <td className="px-6 py-2.5 whitespace-nowrap text-sm font-mono text-[#5E6C84] border-b border-[#E2E8F0]">{result.order_id}</td>
+                        <td className="px-6 py-2.5 whitespace-nowrap text-sm font-mono border-b border-[#E2E8F0]">
+                          <Link
+                            to={`/orders?q=${encodeURIComponent(result.order_id)}`}
+                            className="text-[#0055FF] hover:underline"
+                            title={`View order ${result.order_id}`}
+                          >
+                            {result.order_id}
+                          </Link>
+                        </td>
                         <td className="px-6 py-2.5 whitespace-nowrap text-sm font-medium text-[#1A1C20] border-b border-[#E2E8F0]">{result.parameter}</td>
                         <td className="px-6 py-2.5 whitespace-nowrap text-sm font-mono text-[#1A1C20] border-b border-[#E2E8F0]">
                           {result.value} {result.unit}

--- a/frontend/src/pages/Results.tsx
+++ b/frontend/src/pages/Results.tsx
@@ -173,7 +173,7 @@ export const Results = () => {
             <ErrorBanner message={error || null} onRetry={error ? refetch : undefined} />
 
             {loading ? (
-              <div className="flex items-center justify-center py-12">
+              <div role="status" aria-live="polite" className="flex items-center justify-center py-12">
                 <div className="text-center">
                   <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto"></div>
                   <p className="mt-4 text-gray-600">Loading results...</p>

--- a/frontend/src/pages/Results.tsx
+++ b/frontend/src/pages/Results.tsx
@@ -30,7 +30,6 @@ export const Results = () => {
   const [selectedResult, setSelectedResult] = useState<TestResult | null>(null);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const [resultToDelete, setResultToDelete] = useState<TestResult | null>(null);
-  const [deleteError, setDeleteError] = useState<string | null>(null);
   const itemsPerPage = 20;
 
   const { data: results, total: totalResults, loading, error, refetch } = useEntityList(
@@ -91,18 +90,12 @@ export const Results = () => {
     setIsDeleteDialogOpen(true);
   };
 
+  // Errors propagate to DeleteConfirmDialog (shown inline; dialog stays open).
   const handleDeleteConfirm = async () => {
     if (!resultToDelete) return;
-    setDeleteError(null);
-    try {
-      await deleteResult(resultToDelete.result_id);
-      toast.success(`Result ${resultToDelete.result_id} rejected`);
-      setIsDeleteDialogOpen(false);
-      setResultToDelete(null);
-      refetch();
-    } catch (err) {
-      setDeleteError(err instanceof Error ? err.message : 'Delete failed');
-    }
+    await deleteResult(resultToDelete.result_id);
+    toast.success(`Result ${resultToDelete.result_id} rejected`);
+    refetch();
   };
 
   return (
@@ -175,7 +168,7 @@ export const Results = () => {
               </div>
             </div>
 
-            <ErrorBanner message={deleteError || error || null} />
+            <ErrorBanner message={error || null} onRetry={error ? refetch : undefined} />
 
             {loading ? (
               <div className="flex items-center justify-center py-12">
@@ -370,9 +363,11 @@ export const Results = () => {
           setResultToDelete(null);
         }}
         onConfirm={handleDeleteConfirm}
-        title="Delete Test Result"
-        message="Are you sure you want to delete this test result? This will permanently remove all associated data."
+        title="Reject Test Result"
+        message="Reject this test result?"
         itemName={resultToDelete?.result_id}
+        confirmText="Reject"
+        outcomeNote="The result is marked REJECTED (soft-delete). Its audit history is retained."
       />
     </Layout>
   );

--- a/frontend/src/pages/Samples.tsx
+++ b/frontend/src/pages/Samples.tsx
@@ -37,7 +37,6 @@ export const Samples = () => {
   const [selectedSampleId, setSelectedSampleId] = useState<string | null>(null);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const [sampleToDelete, setSampleToDelete] = useState<Sample | null>(null);
-  const [deleteError, setDeleteError] = useState<string | null>(null);
   const itemsPerPage = 20;
 
   const { data: samples, total: totalSamples, loading, error, refetch } = useEntityList(
@@ -83,18 +82,13 @@ export const Samples = () => {
     setIsDeleteDialogOpen(true);
   };
 
+  // Errors propagate to DeleteConfirmDialog, which shows them inline and keeps
+  // itself open; on success the dialog calls onClose (which clears the state).
   const handleDeleteConfirm = async () => {
     if (!sampleToDelete) return;
-    setDeleteError(null);
-    try {
-      await deleteSample(sampleToDelete.sample_id);
-      toast.success(`Sample ${sampleToDelete.sample_id} archived`);
-      setIsDeleteDialogOpen(false);
-      setSampleToDelete(null);
-      refetch();
-    } catch (err) {
-      setDeleteError(err instanceof Error ? err.message : 'Delete failed');
-    }
+    await deleteSample(sampleToDelete.sample_id);
+    toast.success(`Sample ${sampleToDelete.sample_id} archived`);
+    refetch();
   };
 
   return (
@@ -161,7 +155,7 @@ export const Samples = () => {
             </div>
           </div>
 
-          <ErrorBanner message={deleteError || error || null} />
+          <ErrorBanner message={error || null} onRetry={error ? refetch : undefined} />
 
           {loading ? (
             <div className="flex items-center justify-center py-12">
@@ -376,9 +370,11 @@ export const Samples = () => {
           setSampleToDelete(null);
         }}
         onConfirm={handleDeleteConfirm}
-        title="Delete Sample"
-        message="Are you sure you want to delete this sample? This will permanently remove all associated data."
+        title="Archive Sample"
+        message="Archive this sample? It will be hidden from active lists."
         itemName={sampleToDelete?.sample_id}
+        confirmText="Archive"
+        outcomeNote="The sample is marked ARCHIVED (soft-delete). Its audit history is retained."
       />
     </Layout>
   );

--- a/frontend/src/pages/Samples.tsx
+++ b/frontend/src/pages/Samples.tsx
@@ -158,7 +158,7 @@ export const Samples = () => {
           <ErrorBanner message={error || null} onRetry={error ? refetch : undefined} />
 
           {loading ? (
-            <div className="flex items-center justify-center py-12">
+            <div role="status" aria-live="polite" className="flex items-center justify-center py-12">
               <div className="text-center">
                 <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto"></div>
                 <p className="mt-4 text-gray-600">Loading samples...</p>

--- a/frontend/src/pages/Samples.tsx
+++ b/frontend/src/pages/Samples.tsx
@@ -13,10 +13,12 @@ import { SAMPLE_STATUSES } from '../utils/constants';
 import { useDocumentTitle } from '../hooks/useDocumentTitle';
 import { useAuth } from '../context/AuthContext';
 import { useEntityList } from '../hooks/useEntityList';
+import { useToast } from '../hooks/useToast';
 
 export const Samples = () => {
   useDocumentTitle({ module: 'Samples' });
   const { user } = useAuth();
+  const toast = useToast();
   const canWrite = user?.role === 'ADMIN' || user?.role === 'OPERATOR';
   const location = useLocation();
   const [searchQuery, setSearchQuery] = useState<string>('');
@@ -61,7 +63,8 @@ export const Samples = () => {
     window.scrollTo({ top: 0, behavior: 'smooth' });
   };
 
-  const handleCreateSuccess = (_newSample: Sample) => {
+  const handleCreateSuccess = (newSample: Sample) => {
+    toast.success(`Sample ${newSample.sample_id} created`);
     refetch();
   };
 
@@ -70,7 +73,8 @@ export const Samples = () => {
     setIsEditModalOpen(true);
   };
 
-  const handleEditSuccess = (_updatedSample: Sample) => {
+  const handleEditSuccess = (updatedSample: Sample) => {
+    toast.success(`Sample ${updatedSample.sample_id} updated`);
     refetch();
   };
 
@@ -84,6 +88,7 @@ export const Samples = () => {
     setDeleteError(null);
     try {
       await deleteSample(sampleToDelete.sample_id);
+      toast.success(`Sample ${sampleToDelete.sample_id} archived`);
       setIsDeleteDialogOpen(false);
       setSampleToDelete(null);
       refetch();

--- a/frontend/src/pages/Users.tsx
+++ b/frontend/src/pages/Users.tsx
@@ -8,11 +8,15 @@ import type { User, CreateUserPayload, UpdateUserPayload, UserRole } from '../ty
 import { USER_ROLES, ROLE_COLORS } from '../types/user';
 import { useDocumentTitle } from '../hooks/useDocumentTitle';
 import { ErrorBanner } from '../components/common/ErrorBanner';
+import { DeleteConfirmDialog } from '../components/common/DeleteConfirmDialog';
 import { useAuth } from '../context/AuthContext';
+import { useToast } from '../hooks/useToast';
 
 export const Users = () => {
   useDocumentTitle({ module: 'User Management' });
   const { user: currentUser } = useAuth();
+  const toast = useToast();
+  const [userToDelete, setUserToDelete] = useState<User | null>(null);
   const isAdmin = currentUser?.role === 'ADMIN';
   const [users, setUsers] = useState<User[]>([]);
   const [deletingUserId, setDeletingUserId] = useState<number | null>(null);
@@ -72,15 +76,14 @@ export const Users = () => {
     }
   };
 
-  const handleDeleteUser = async (userId: number) => {
-    if (!confirm('Are you sure you want to delete this user?')) return;
-    if (deletingUserId !== null) return;
-    setDeletingUserId(userId);
+  const confirmDeleteUser = async () => {
+    if (!userToDelete) return;
+    setDeletingUserId(userToDelete.id);
     try {
-      await deleteUser(userId);
+      await deleteUser(userToDelete.id);
+      toast.success(`User ${userToDelete.username} deleted`);
+      setUserToDelete(null);
       await fetchUsers();
-    } catch (err: unknown) {
-      setError((err && typeof err === 'object' && 'response' in err ? (err as {response?: {data?: {error?: {message?: string}}}}).response?.data?.error?.message : undefined) || 'Failed to delete user');
     } finally {
       setDeletingUserId(null);
     }
@@ -179,7 +182,7 @@ export const Users = () => {
                             Edit
                           </button>
                           <button
-                            onClick={() => handleDeleteUser(user.id)}
+                            onClick={() => setUserToDelete(user)}
                             disabled={deletingUserId === user.id}
                             className="text-red-600 hover:text-red-900 disabled:opacity-50 disabled:cursor-not-allowed"
                           >
@@ -210,6 +213,17 @@ export const Users = () => {
           onSubmit={(payload) => handleUpdateUser(editingUser.id, payload)}
         />
       )}
+
+      <DeleteConfirmDialog
+        isOpen={userToDelete !== null}
+        onClose={() => setUserToDelete(null)}
+        onConfirm={confirmDeleteUser}
+        title="Delete User"
+        message="Delete this user account? They will no longer be able to sign in."
+        itemName={userToDelete?.username}
+        confirmText="Delete User"
+        outcomeNote="This is recorded in the audit trail."
+      />
     </Layout>
   );
 };

--- a/frontend/src/pages/Users.tsx
+++ b/frontend/src/pages/Users.tsx
@@ -263,7 +263,7 @@ const UserModal = ({ user, onClose, onSubmit }: UserModalProps) => {
   };
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50">
       <div className="bg-white rounded shadow-xl max-w-2xl w-full max-h-[90vh] overflow-y-auto">
         <div className="p-6">
           <div className="flex justify-between items-center mb-6">

--- a/frontend/src/utils/resultFlag.ts
+++ b/frontend/src/utils/resultFlag.ts
@@ -1,0 +1,26 @@
+import type { TestResult } from '../types/result';
+
+/**
+ * Auto-flag a numeric result against its reference range. Mirrors the backend
+ * margin-based rule (CRITICAL = 50% of the reference interval beyond the bounds).
+ * Returns UNDEFINED when the value or range isn't a usable finite range — shared
+ * by the create and edit modals so an edited value can't keep a stale flag.
+ */
+export function computeFlag(
+  value: string,
+  refMin: string,
+  refMax: string
+): TestResult['flag'] {
+  const v = parseFloat(value);
+  if (!Number.isFinite(v)) return 'UNDEFINED';
+  const min = parseFloat(refMin);
+  const max = parseFloat(refMax);
+  if (!Number.isFinite(min) || !Number.isFinite(max) || min >= max) return 'UNDEFINED';
+  const margin = (max - min) * 0.5;
+  const criticalLow = min - margin;
+  const criticalHigh = max + margin;
+  if (v < criticalLow || v > criticalHigh) return 'CRITICAL';
+  if (v < min) return 'LOW';
+  if (v > max) return 'HIGH';
+  return 'NORMAL';
+}


### PR DESCRIPTION
A six-batch UX pass driven by a five-dimension survey (accessibility, feedback/states, forms, design-system fidelity, navigation) against DESIGN.md. Every batch was built + validated (tsc, lint, vitest 46, Playwright e2e 7) before commit.

### 1 · Design-system foundation
Tailwind runs **v4**, which ignored `tailwind.config.js` — the whole `clinical-*`/`font-mono` token layer generated no CSS and `bg-opacity-50` was a no-op (modal backdrops rendered **solid black**). Added a v4 `@theme` token block, fixed all 9 backdrops to `bg-black/50`, unified the primary blue to `#0055FF`, applied tabular-nums to the data font.

### 2 · Shared primitives
`Input` label association (useId) + required/aria; `ErrorBanner` role=alert + Retry; new `Toast` (ToastProvider/useToast) with success wiring on all create/update/delete.

### 2b/3 · Trustworthy delete flow
`useModalA11y` (focus-trap, Esc, focus-restore, scroll-lock) on the delete dialog; corrected the false "cannot be undone" to accurate soft-delete outcomes (ARCHIVED/CANCELLED/REJECTED); migrated Users off native `confirm()`; errors show in-dialog; list errors get Retry.

### 4 · Data-entry safety
Shared `computeFlag`; **ResultEditModal now recomputes the auto-flag on value/range edits** (was keeping stale flags — a patient-safety hazard); numeric `inputMode` on result fields; MFA numeric-only; login error shown once (not misattributed to the password field).

### 5 · Cross-entity navigation
Sample→Order→Result IDs are now links; Dashboard Critical tile → filtered critical list; Results reads `?flag`/`?status`; breadcrumb `/import` fixed.

### 6 · a11y polish
Skip-to-content link, `aria-current` on active nav, `role=status` on loaders.

Remaining (follow-ups, not in this PR): URL-persisted filters on all list pages, sidebar icon-only redesign + responsive drawer, a shared StatusBadge, a read-only detail view for VIEWER, shadows→borders.

https://claude.ai/code/session_01QwRSUQRhHR4mkfvvaoqnYJ