### PR TITLE
feat(ux): URL-persisted filters + shared StatusBadge (batches 7-8)

### DIFF
--- a/frontend/src/components/common/StatusBadge.tsx
+++ b/frontend/src/components/common/StatusBadge.tsx
@@ -1,0 +1,23 @@
+import type { ReactNode } from 'react';
+
+interface StatusBadgeProps {
+  /** Tailwind color classes, e.g. from STATUS_COLORS / RESULT_FLAG_COLORS. */
+  colorClass?: string;
+  children: ReactNode;
+}
+
+/**
+ * The one status/flag/priority badge. Rectangular (2px radius), uppercase,
+ * bordered — per DESIGN.md §4B ("Rectangular tags, no soft pills"). Callers pass
+ * the semantic color class; this owns the shape so every badge looks the same.
+ */
+export const StatusBadge = ({
+  colorClass = 'bg-gray-100 text-gray-700 border-gray-300',
+  children,
+}: StatusBadgeProps) => (
+  <span
+    className={`inline-flex items-center rounded-[2px] border px-2 py-0.5 text-xs font-semibold uppercase tracking-wide ${colorClass}`}
+  >
+    {children}
+  </span>
+);

--- a/frontend/src/hooks/useListParams.ts
+++ b/frontend/src/hooks/useListParams.ts
@@ -1,0 +1,49 @@
+import { useCallback } from 'react';
+import { useSearchParams } from 'react-router-dom';
+
+/**
+ * List-page filter/pagination state backed by the URL query string, so filters
+ * and the current page survive navigation, are deep-linkable, and work with the
+ * browser back button. Setting a filter resets the page; history uses replace so
+ * a filter tweak doesn't spam the back stack.
+ */
+export function useListParams() {
+  const [params, setParams] = useSearchParams();
+
+  const get = (key: string, def = ''): string => params.get(key) ?? def;
+
+  const page = Math.max(1, parseInt(params.get('page') ?? '1', 10) || 1);
+
+  const setParam = useCallback(
+    (key: string, value: string, resetPage = true) => {
+      setParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          if (value) next.set(key, value);
+          else next.delete(key);
+          if (resetPage) next.delete('page');
+          return next;
+        },
+        { replace: true }
+      );
+    },
+    [setParams]
+  );
+
+  const setPage = useCallback(
+    (p: number) => {
+      setParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          if (p > 1) next.set('page', String(p));
+          else next.delete('page');
+          return next;
+        },
+        { replace: true }
+      );
+    },
+    [setParams]
+  );
+
+  return { get, page, setParam, setPage };
+}

--- a/frontend/src/pages/Orders.tsx
+++ b/frontend/src/pages/Orders.tsx
@@ -1,5 +1,5 @@
-import { useState, useEffect } from 'react';
-import { useLocation, Link } from 'react-router-dom';
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
 import { Layout } from '../components/Layout/Layout';
 import { Card } from '../components/common/Card';
 import { Button } from '../components/common/Button';
@@ -14,24 +14,18 @@ import { useDocumentTitle } from '../hooks/useDocumentTitle';
 import { useAuth } from '../context/AuthContext';
 import { useEntityList } from '../hooks/useEntityList';
 import { useToast } from '../hooks/useToast';
+import { useListParams } from '../hooks/useListParams';
 
 export const Orders = () => {
   useDocumentTitle({ module: 'Orders' });
   const { user } = useAuth();
   const toast = useToast();
   const canWrite = user?.role === 'ADMIN' || user?.role === 'OPERATOR';
-  const location = useLocation();
-  const [searchQuery, setSearchQuery] = useState<string>('');
-  const [selectedStatus, setSelectedStatus] = useState<string>('');
-  const [selectedPriority, setSelectedPriority] = useState<string>('');
-  const [currentPage, setCurrentPage] = useState(1);
+  const { get, page: currentPage, setParam, setPage } = useListParams();
+  const searchQuery = get('q');
+  const selectedStatus = get('status');
+  const selectedPriority = get('priority');
 
-  useEffect(() => {
-    const params = new URLSearchParams(location.search);
-    const q = params.get('q') || '';
-    setSearchQuery(q);
-    setCurrentPage(1);
-  }, [location.search]);
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
   const [selectedOrderId, setSelectedOrderId] = useState<string | null>(null);
@@ -54,7 +48,7 @@ export const Orders = () => {
   const totalPages = Math.ceil(totalOrders / itemsPerPage);
 
   const handlePageChange = (page: number) => {
-    setCurrentPage(page);
+    setPage(page);
     window.scrollTo({ top: 0, behavior: 'smooth' });
   };
 
@@ -120,11 +114,8 @@ export const Orders = () => {
                 </label>
                 <select
                   value={selectedStatus}
-                  onChange={(e) => {
-                    setSelectedStatus(e.target.value);
-                    setCurrentPage(1);
-                  }}
-                  className="w-full px-3 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  onChange={(e) => setParam('status', e.target.value)}
+                  className="w-full px-3 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-[#0055FF] focus:border-transparent"
                 >
                   <option value="">All Statuses</option>
                   {Object.entries(ORDER_STATUSES).map(([key, label]) => (
@@ -141,11 +132,8 @@ export const Orders = () => {
                 </label>
                 <select
                   value={selectedPriority}
-                  onChange={(e) => {
-                    setSelectedPriority(e.target.value);
-                    setCurrentPage(1);
-                  }}
-                  className="w-full px-3 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  onChange={(e) => setParam('priority', e.target.value)}
+                  className="w-full px-3 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-[#0055FF] focus:border-transparent"
                 >
                   <option value="">All Priorities</option>
                   {Object.entries(ORDER_PRIORITIES).map(([key, label]) => (

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { Layout } from '../components/Layout/Layout';
 import { Card } from '../components/common/Card';
+import { StatusBadge } from '../components/common/StatusBadge';
 import { Input } from '../components/common/Input';
 import { Button } from '../components/common/Button';
 import { getCurrentUser, changePassword } from '../services/users';
@@ -106,9 +107,9 @@ export const Profile = () => {
                   Role
                 </label>
                 <div>
-                  <span className={`px-3 py-1 inline-flex text-xs leading-5 font-semibold rounded-full ${ROLE_COLORS[user.role]}`}>
+                  <StatusBadge colorClass={ROLE_COLORS[user.role]}>
                     {USER_ROLES[user.role]}
-                  </span>
+                  </StatusBadge>
                 </div>
               </div>
 
@@ -135,9 +136,9 @@ export const Profile = () => {
                   Account Status
                 </label>
                 <div>
-                  <span className={`px-3 py-1 inline-flex text-xs leading-5 font-semibold rounded-full ${user.active ? 'bg-green-100 text-green-800' : 'bg-gray-100 text-gray-800'}`}>
+                  <StatusBadge colorClass={user.active ? 'bg-green-100 text-green-800 border-green-200' : 'bg-gray-100 text-gray-800 border-gray-300'}>
                     {user.active ? 'Active' : 'Inactive'}
-                  </span>
+                  </StatusBadge>
                 </div>
               </div>
 

--- a/frontend/src/pages/Results.tsx
+++ b/frontend/src/pages/Results.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useMemo, useState } from 'react';
-import { useLocation, Link } from 'react-router-dom';
+import { useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
 import { Layout } from '../components/Layout/Layout';
 import { Card } from '../components/common/Card';
 import { Button } from '../components/common/Button';
@@ -14,17 +14,17 @@ import { useDocumentTitle } from '../hooks/useDocumentTitle';
 import { useAuth } from '../context/AuthContext';
 import { useEntityList } from '../hooks/useEntityList';
 import { useToast } from '../hooks/useToast';
+import { useListParams } from '../hooks/useListParams';
 
 export const Results = () => {
   useDocumentTitle({ module: 'Test Results' });
   const { user } = useAuth();
   const toast = useToast();
   const canWrite = user?.role === 'ADMIN' || user?.role === 'OPERATOR';
-  const location = useLocation();
-  const [searchQuery, setSearchQuery] = useState<string>('');
-  const [selectedStatus, setSelectedStatus] = useState<string>('');
-  const [selectedFlag, setSelectedFlag] = useState<string>('');
-  const [currentPage, setCurrentPage] = useState(1);
+  const { get, page: currentPage, setParam, setPage } = useListParams();
+  const searchQuery = get('q');
+  const selectedStatus = get('status');
+  const selectedFlag = get('flag');
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
   const [selectedResult, setSelectedResult] = useState<TestResult | null>(null);
@@ -43,17 +43,9 @@ export const Results = () => {
     [selectedStatus, selectedFlag, currentPage]
   );
 
-  // Read ?q= from the URL (header global search routes result-id lookups here).
-  // The /results backend endpoint has no server-side text search, so filter the
-  // loaded page client-side by result id / parameter / order id.
-  useEffect(() => {
-    const params = new URLSearchParams(location.search);
-    setSearchQuery(params.get('q') || '');
-    setSelectedFlag(params.get('flag') || '');
-    setSelectedStatus(params.get('status') || '');
-    setCurrentPage(1);
-  }, [location.search]);
-
+  // ?q from the header global search filters the loaded page client-side (the
+  // /results endpoint has no server-side text search); ?status/?flag are server
+  // filters read from the URL via useListParams.
   const displayedResults = useMemo(() => {
     const q = searchQuery.trim().toLowerCase();
     if (!q) return results;
@@ -68,7 +60,7 @@ export const Results = () => {
   const totalPages = Math.ceil(totalResults / itemsPerPage);
 
   const handlePageChange = (page: number) => {
-    setCurrentPage(page);
+    setPage(page);
     window.scrollTo({ top: 0, behavior: 'smooth' });
   };
 
@@ -133,11 +125,8 @@ export const Results = () => {
                 </label>
                 <select
                   value={selectedStatus}
-                  onChange={(e) => {
-                    setSelectedStatus(e.target.value);
-                    setCurrentPage(1);
-                  }}
-                  className="w-full px-3 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  onChange={(e) => setParam('status', e.target.value)}
+                  className="w-full px-3 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-[#0055FF] focus:border-transparent"
                 >
                   <option value="">All Statuses</option>
                   {Object.entries(RESULT_STATUSES).map(([key, label]) => (
@@ -154,11 +143,8 @@ export const Results = () => {
                 </label>
                 <select
                   value={selectedFlag}
-                  onChange={(e) => {
-                    setSelectedFlag(e.target.value);
-                    setCurrentPage(1);
-                  }}
-                  className="w-full px-3 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  onChange={(e) => setParam('flag', e.target.value)}
+                  className="w-full px-3 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-[#0055FF] focus:border-transparent"
                 >
                   <option value="">All Flags</option>
                   {Object.entries(RESULT_FLAGS).map(([key, label]) => (

--- a/frontend/src/pages/Samples.tsx
+++ b/frontend/src/pages/Samples.tsx
@@ -3,6 +3,7 @@ import { Layout } from '../components/Layout/Layout';
 import { Card } from '../components/common/Card';
 import { Button } from '../components/common/Button';
 import { ErrorBanner } from '../components/common/ErrorBanner';
+import { StatusBadge } from '../components/common/StatusBadge';
 import { DeleteConfirmDialog } from '../components/common/DeleteConfirmDialog';
 import { SampleCreateModal } from '../components/Samples/SampleCreateModal';
 import { SampleEditModal } from '../components/Samples/SampleEditModal';
@@ -205,16 +206,14 @@ export const Samples = () => {
                           {sample.description}
                         </td>
                         <td className="px-3 md:px-6 py-2 md:py-2.5 whitespace-nowrap border-b border-[#E2E8F0]">
-                          <span className={`px-2 py-1 text-[10px] font-bold uppercase tracking-wider border inline-block ${
+                          <StatusBadge colorClass={
                             sample.status === 'REGISTERED' ? 'bg-blue-50 text-blue-700 border-blue-200' :
                             sample.status === 'IN_ANALYSIS' ? 'bg-yellow-50 text-yellow-800 border-yellow-200' :
-                            sample.status === 'ANALYZED' ? 'bg-gray-100 text-gray-700 border-gray-300' :
                             sample.status === 'VALIDATED' ? 'bg-green-50 text-green-700 border-green-200' :
-                            sample.status === 'ARCHIVED' ? 'bg-gray-100 text-gray-600 border-gray-300' :
-                            'bg-gray-100 text-gray-600 border-gray-300'
-                          }`}>
+                            'bg-gray-100 text-gray-700 border-gray-300'
+                          }>
                             {sample.status.replace('_', ' ')}
-                          </span>
+                          </StatusBadge>
                         </td>
                         <td className="px-3 md:px-6 py-2 md:py-2.5 whitespace-nowrap text-sm font-mono text-[#5E6C84] border-b border-[#E2E8F0]">
                           {new Date(sample.created_at).toLocaleDateString('de-DE')}

--- a/frontend/src/pages/Samples.tsx
+++ b/frontend/src/pages/Samples.tsx
@@ -1,5 +1,4 @@
-import { useState, useEffect } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useState } from 'react';
 import { Layout } from '../components/Layout/Layout';
 import { Card } from '../components/common/Card';
 import { Button } from '../components/common/Button';
@@ -14,24 +13,17 @@ import { useDocumentTitle } from '../hooks/useDocumentTitle';
 import { useAuth } from '../context/AuthContext';
 import { useEntityList } from '../hooks/useEntityList';
 import { useToast } from '../hooks/useToast';
+import { useListParams } from '../hooks/useListParams';
 
 export const Samples = () => {
   useDocumentTitle({ module: 'Samples' });
   const { user } = useAuth();
   const toast = useToast();
   const canWrite = user?.role === 'ADMIN' || user?.role === 'OPERATOR';
-  const location = useLocation();
-  const [searchQuery, setSearchQuery] = useState<string>('');
-  const [selectedStatus, setSelectedStatus] = useState<string>('');
-  const [currentPage, setCurrentPage] = useState(1);
+  const { get, page: currentPage, setParam, setPage } = useListParams();
+  const searchQuery = get('q');
+  const selectedStatus = get('status');
 
-  // Read ?q= from URL on mount and when URL changes
-  useEffect(() => {
-    const params = new URLSearchParams(location.search);
-    const q = params.get('q') || '';
-    setSearchQuery(q);
-    setCurrentPage(1);
-  }, [location.search]);
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
   const [selectedSampleId, setSelectedSampleId] = useState<string | null>(null);
@@ -53,12 +45,11 @@ export const Samples = () => {
   const totalPages = Math.ceil(totalSamples / itemsPerPage);
 
   const handleStatusFilter = (status: string) => {
-    setSelectedStatus(status);
-    setCurrentPage(1);
+    setParam('status', status);
   };
 
   const handlePageChange = (page: number) => {
-    setCurrentPage(page);
+    setPage(page);
     window.scrollTo({ top: 0, behavior: 'smooth' });
   };
 
@@ -127,7 +118,7 @@ export const Samples = () => {
             <div className="mb-4 flex items-center gap-2 text-sm text-blue-700 bg-blue-50 border border-blue-200 rounded px-3 py-2">
               <svg className="w-4 h-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/></svg>
               <span>Suche: <strong>{searchQuery}</strong></span>
-              <button className="ml-auto text-blue-500 hover:text-blue-700" onClick={() => { setSearchQuery(''); setCurrentPage(1); }}>✕</button>
+              <button className="ml-auto text-blue-500 hover:text-blue-700" aria-label="Clear search" onClick={() => setParam('q', '')}>✕</button>
             </div>
           )}
           <div className="mb-6">

--- a/frontend/src/pages/Users.tsx
+++ b/frontend/src/pages/Users.tsx
@@ -8,6 +8,7 @@ import type { User, CreateUserPayload, UpdateUserPayload, UserRole } from '../ty
 import { USER_ROLES, ROLE_COLORS } from '../types/user';
 import { useDocumentTitle } from '../hooks/useDocumentTitle';
 import { ErrorBanner } from '../components/common/ErrorBanner';
+import { StatusBadge } from '../components/common/StatusBadge';
 import { DeleteConfirmDialog } from '../components/common/DeleteConfirmDialog';
 import { useAuth } from '../context/AuthContext';
 import { useToast } from '../hooks/useToast';
@@ -160,14 +161,14 @@ export const Users = () => {
                       {user.email || '-'}
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap">
-                      <span className={`px-3 py-1 inline-flex text-xs leading-5 font-semibold rounded-full ${ROLE_COLORS[user.role]}`}>
+                      <StatusBadge colorClass={ROLE_COLORS[user.role]}>
                         {USER_ROLES[user.role]}
-                      </span>
+                      </StatusBadge>
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap">
-                      <span className={`px-3 py-1 inline-flex text-xs leading-5 font-semibold rounded-full ${user.active ? 'bg-green-100 text-green-800' : 'bg-gray-100 text-gray-800'}`}>
+                      <StatusBadge colorClass={user.active ? 'bg-green-100 text-green-800 border-green-200' : 'bg-gray-100 text-gray-800 border-gray-300'}>
                         {user.active ? 'Active' : 'Inactive'}
-                      </span>
+                      </StatusBadge>
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
                       {user.last_login ? new Date(user.last_login * 1000).toLocaleDateString() : 'Never'}


### PR DESCRIPTION
Two follow-up UX batches after #75.

### 7 · URL-persisted list filters + pagination
New `useListParams` hook backs Samples/Orders/Results filters and page number in the URL query string. Filtered views are now deep-linkable and shareable (e.g. `/orders?status=…&priority=…&page=3`), survive the back button, and have a single source of truth (removed per-page useState + the ?q sync effects). Filter select focus rings unified to #0055FF.

### 8 · Shared StatusBadge
One rectangular (2px, bordered, uppercase) badge component per DESIGN.md §4B; replaces the rounded-full pills on Users/Profile and the inline status ternary on Samples.

Verified per batch: tsc clean, lint 0 errors, vitest 46/46, Playwright e2e 7/7.

Remaining follow-ups (not in this PR): sidebar icon-only + responsive drawer, read-only detail view for VIEWER, shadows→borders, adopt StatusBadge across the remaining Orders/Results status+flag+priority cells.

https://claude.ai/code/session_01QwRSUQRhHR4mkfvvaoqnYJ