### PR TITLE
feat(ux): flat surfaces + StatusBadge everywhere (batch 9)

### DIFF
--- a/frontend/src/components/common/Card.tsx
+++ b/frontend/src/components/common/Card.tsx
@@ -8,7 +8,7 @@ interface CardProps {
 
 export const Card = ({ children, title, className = '' }: CardProps) => {
   return (
-    <div className={`bg-white rounded shadow-md overflow-hidden ${className}`}>
+    <div className={`bg-white dark:bg-dark-surface rounded border border-clinical-border dark:border-white/10 overflow-hidden ${className}`}>
       {title && (
         <div className="px-6 py-4 border-b border-gray-200">
           <h3 className="text-lg font-semibold text-gray-900">{title}</h3>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -90,7 +90,7 @@ table {
     background: var(--bg-surface);
     border-radius: 4px; /* Minimal Radius */
     overflow: hidden;
-    box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06); /* Card Effect */
+    border: 1px solid var(--border-subtle); /* Flat: borders, not shadows */
     margin-bottom: 2rem;
 }
 

--- a/frontend/src/pages/Orders.tsx
+++ b/frontend/src/pages/Orders.tsx
@@ -4,6 +4,7 @@ import { Layout } from '../components/Layout/Layout';
 import { Card } from '../components/common/Card';
 import { Button } from '../components/common/Button';
 import { ErrorBanner } from '../components/common/ErrorBanner';
+import { StatusBadge } from '../components/common/StatusBadge';
 import { DeleteConfirmDialog } from '../components/common/DeleteConfirmDialog';
 import { OrderCreateModal } from '../components/Orders/OrderCreateModal';
 import { OrderEditModal } from '../components/Orders/OrderEditModal';
@@ -209,25 +210,24 @@ export const Orders = () => {
                           {order.test_type}
                         </td>
                         <td className="px-3 md:px-6 py-2 md:py-2.5 whitespace-nowrap border-b border-[#E2E8F0]">
-                          <span className={`px-2 py-1 text-[10px] font-bold uppercase tracking-wider border inline-block ${
+                          <StatusBadge colorClass={
                             order.status === 'REQUESTED' ? 'bg-blue-50 text-blue-700 border-blue-200' :
                             order.status === 'IN_PROGRESS' ? 'bg-yellow-50 text-yellow-800 border-yellow-200' :
-                            order.status === 'COMPLETED' ? 'bg-green-50 text-green-700 border-green-200' :
-                            order.status === 'VALIDATED' ? 'bg-green-50 text-green-700 border-green-200' :
+                            order.status === 'COMPLETED' || order.status === 'VALIDATED' ? 'bg-green-50 text-green-700 border-green-200' :
                             order.status === 'CANCELLED' ? 'bg-red-50 text-red-700 border-red-200' :
                             'bg-gray-100 text-gray-600 border-gray-300'
-                          }`}>
+                          }>
                             {order.status.replace('_', ' ')}
-                          </span>
+                          </StatusBadge>
                         </td>
                         <td className="px-3 md:px-6 py-2 md:py-2.5 whitespace-nowrap border-b border-[#E2E8F0]">
-                          <span className={`px-2 py-1 text-[10px] font-bold uppercase tracking-wider border inline-block ${
+                          <StatusBadge colorClass={
                             order.priority === 'EMERGENCY' ? 'bg-red-50 text-red-700 border-red-200' :
                             order.priority === 'URGENT' ? 'bg-orange-50 text-orange-700 border-orange-200' :
                             'bg-gray-100 text-gray-700 border-gray-300'
-                          }`}>
+                          }>
                             {order.priority}
-                          </span>
+                          </StatusBadge>
                         </td>
                         <td className="px-3 md:px-6 py-2 md:py-2.5 whitespace-nowrap text-sm text-[#5E6C84] border-b border-[#E2E8F0]">
                           {order.requested_by}

--- a/frontend/src/pages/Results.tsx
+++ b/frontend/src/pages/Results.tsx
@@ -4,6 +4,7 @@ import { Layout } from '../components/Layout/Layout';
 import { Card } from '../components/common/Card';
 import { Button } from '../components/common/Button';
 import { ErrorBanner } from '../components/common/ErrorBanner';
+import { StatusBadge } from '../components/common/StatusBadge';
 import { DeleteConfirmDialog } from '../components/common/DeleteConfirmDialog';
 import { ResultCreateModal } from '../components/Results/ResultCreateModal';
 import { ResultEditModal } from '../components/Results/ResultEditModal';
@@ -207,26 +208,26 @@ export const Results = () => {
                           {result.reference_min} - {result.reference_max}
                         </td>
                         <td className="px-6 py-2.5 whitespace-nowrap border-b border-[#E2E8F0]">
-                          <span className={`px-2 py-1 text-[10px] font-bold uppercase tracking-wider border inline-block ${
+                          <StatusBadge colorClass={
                             result.flag === 'CRITICAL' ? 'bg-red-50 text-red-700 border-red-200' :
                             result.flag === 'HIGH' ? 'bg-orange-50 text-orange-700 border-orange-200' :
                             result.flag === 'LOW' ? 'bg-yellow-50 text-yellow-800 border-yellow-200' :
                             result.flag === 'UNDEFINED' ? 'bg-gray-100 text-gray-600 border-gray-300' :
                             'bg-green-50 text-green-700 border-green-200'
-                          }`}>
+                          }>
                             {RESULT_FLAGS[result.flag]}
-                          </span>
+                          </StatusBadge>
                         </td>
                         <td className="px-6 py-2.5 whitespace-nowrap border-b border-[#E2E8F0]">
-                          <span className={`px-2 py-1 text-[10px] font-bold uppercase tracking-wider border inline-block ${
+                          <StatusBadge colorClass={
                             result.status === 'PENDING' ? 'bg-yellow-50 text-yellow-800 border-yellow-200' :
                             result.status === 'VALIDATED' ? 'bg-green-50 text-green-700 border-green-200' :
                             result.status === 'ENTERED' ? 'bg-blue-50 text-blue-700 border-blue-200' :
                             result.status === 'REJECTED' ? 'bg-red-50 text-red-700 border-red-200' :
                             'bg-gray-100 text-gray-600 border-gray-300'
-                          }`}>
+                          }>
                             {RESULT_STATUSES[result.status]}
-                          </span>
+                          </StatusBadge>
                         </td>
                         <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium border-b border-[#E2E8F0]">
                           {canWrite && <div className="flex items-center justify-end gap-2">


### PR DESCRIPTION
Follow-up UX batch after #76.

- StatusBadge now backs every status/priority/flag cell (Orders status+priority, Results flag+status) — the last inline badge ternaries are gone.
- Flat surfaces per DESIGN.md: Card and the global table use borders instead of shadows (with dark-mode surfaces/borders).

Verified: tsc clean, lint 0 errors, vitest 46/46, Playwright e2e 7/7.

Remaining: sidebar icon-only + responsive drawer; read-only detail view for VIEWER; e2e login-helper hardening.

https://claude.ai/code/session_01QwRSUQRhHR4mkfvvaoqnYJ