### PR TITLE
feat(ux): responsive sidebar drawer + mobile nav (batch 10)

### DIFF
--- a/frontend/e2e/responsive.spec.ts
+++ b/frontend/e2e/responsive.spec.ts
@@ -1,0 +1,22 @@
+import { test, expect } from '@playwright/test'
+
+// Phone viewport: the sidebar is an off-canvas drawer opened by the header
+// hamburger. Desktop keeps the sidebar always visible (covered elsewhere).
+test.use({ viewport: { width: 390, height: 844 } })
+
+test('mobile: hamburger opens the nav drawer and navigates', async ({ page }) => {
+  await page.goto('/login')
+  await page.getByLabel('Username').fill('admin')
+  await page.getByLabel('Password').fill('admin')
+  await page.getByRole('button', { name: 'Sign In' }).click()
+
+  // Authenticated shell: the mobile menu button is present, the sidebar drawer
+  // is closed (translated off-canvas) until it is pressed.
+  const hamburger = page.getByRole('button', { name: 'Open navigation' })
+  await expect(hamburger).toBeVisible()
+  await hamburger.click()
+
+  // Drawer open → a nav link can be used, and using it navigates + closes.
+  await page.getByRole('link', { name: 'Samples' }).click()
+  await expect(page).toHaveURL(/\/samples/)
+})

--- a/frontend/src/components/Layout/Header.tsx
+++ b/frontend/src/components/Layout/Header.tsx
@@ -2,7 +2,11 @@ import { useState } from 'react';
 import { useAuth } from '../../context/AuthContext';
 import { useLocation, Link, useNavigate } from 'react-router-dom';
 
-export const Header = () => {
+interface HeaderProps {
+  onMenuClick?: () => void;
+}
+
+export const Header = ({ onMenuClick }: HeaderProps) => {
   const { logout } = useAuth();
   const location = useLocation();
   const navigate = useNavigate();
@@ -50,10 +54,20 @@ export const Header = () => {
   };
 
   return (
-    <header className="h-16 bg-white border-b border-gray-200 flex items-center justify-between px-8">
+    <header className="h-16 bg-white border-b border-gray-200 flex items-center justify-between px-4 md:px-8">
       {/* Breadcrumbs - Industrial Wayfinding */}
       <div className="flex items-center text-sm font-medium text-gray-500 font-mono">
-        <Link to="/" className="hover:text-[#0055FF] transition-colors">
+        <button
+          type="button"
+          onClick={onMenuClick}
+          aria-label="Open navigation"
+          className="md:hidden mr-3 text-gray-500 hover:text-[#0055FF] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#0055FF] rounded"
+        >
+          <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+        </button>
+        <Link to="/" aria-label="Home" className="hover:text-[#0055FF] transition-colors">
           <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
           </svg>

--- a/frontend/src/components/Layout/Layout.tsx
+++ b/frontend/src/components/Layout/Layout.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import type { ReactNode } from 'react';
 import { Header } from './Header';
 import { Sidebar } from './Sidebar';
@@ -7,6 +8,8 @@ interface LayoutProps {
 }
 
 export const Layout = ({ children }: LayoutProps) => {
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+
   return (
     <div className="min-h-screen bg-[#F4F5F7]">
       <a
@@ -15,9 +18,20 @@ export const Layout = ({ children }: LayoutProps) => {
       >
         Skip to content
       </a>
-      <Sidebar />
-      <div className="ml-64 flex flex-col min-h-screen">
-        <Header />
+
+      <Sidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />
+
+      {/* Mobile drawer backdrop */}
+      {sidebarOpen && (
+        <div
+          className="fixed inset-0 z-40 bg-black/50 md:hidden"
+          aria-hidden="true"
+          onClick={() => setSidebarOpen(false)}
+        />
+      )}
+
+      <div className="md:ml-64 flex flex-col min-h-screen">
+        <Header onMenuClick={() => setSidebarOpen(true)} />
         <main id="main-content" tabIndex={-1} className="flex-1 p-6 lg:p-8 page-transition">
           {children}
         </main>

--- a/frontend/src/components/Layout/Sidebar.tsx
+++ b/frontend/src/components/Layout/Sidebar.tsx
@@ -1,7 +1,12 @@
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { useAuth } from '../../context/AuthContext';
 
-export const Sidebar = () => {
+interface SidebarProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export const Sidebar = ({ isOpen, onClose }: SidebarProps) => {
   const location = useLocation();
   const navigate = useNavigate();
   const { user, logout } = useAuth();
@@ -107,7 +112,22 @@ export const Sidebar = () => {
   };
 
   return (
-    <aside className="fixed inset-y-0 left-0 w-64 bg-[#1A1C20] border-r border-gray-800 flex flex-col z-50 transition-all duration-300">
+    <aside
+      className={`fixed inset-y-0 left-0 w-64 bg-[#1A1C20] border-r border-gray-800 flex flex-col z-50 transform transition-transform duration-300 md:translate-x-0 ${
+        isOpen ? 'translate-x-0' : '-translate-x-full'
+      }`}
+      aria-label="Main navigation"
+    >
+      {/* Mobile close button */}
+      <button
+        onClick={onClose}
+        aria-label="Close navigation"
+        className="md:hidden absolute top-3 right-3 text-gray-400 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-[#0055FF] rounded"
+      >
+        <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M6 18L18 6M6 6l12 12" />
+        </svg>
+      </button>
       {/* Header */}
       <div className="flex flex-col items-center py-5 px-4 border-b border-gray-800 bg-[#15171a]">
         {/* Logo */}
@@ -132,6 +152,8 @@ export const Sidebar = () => {
           <Link
             key={item.path}
             to={item.path}
+            onClick={onClose}
+            title={item.name}
             aria-current={isActive(item.path) ? 'page' : undefined}
             className={`group flex items-center px-5 py-3 text-sm font-medium transition-colors border-l-4 ${
               isActive(item.path)
@@ -166,6 +188,8 @@ export const Sidebar = () => {
           <Link
             key={item.path}
             to={item.path}
+            onClick={onClose}
+            title={item.name}
             aria-current={isActive(item.path) ? 'page' : undefined}
             className={`group flex items-center px-5 py-3 text-sm font-medium transition-colors border-l-4 ${
               isActive(item.path)


### PR DESCRIPTION
The app shell hardcoded `ml-64` at every breakpoint with a fixed `w-64` sidebar → unusable below md (sidebar overlapped content still pushed 256px right). This makes the sidebar a proper responsive drawer.

- **Mobile (< md):** off-canvas drawer (`-translate-x-full`), opened by a header hamburger, with a backdrop and an in-drawer close button; nav clicks close it.
- **Desktop (md+):** unchanged — always-visible `w-64` sidebar (`md:translate-x-0`), so existing nav is untouched.
- Nav items gain `title` tooltips; the home breadcrumb gains an aria-label.
- **New Playwright test (390×844)** exercises the drawer end-to-end (hamburger → nav → navigate), so the responsive path is covered.

Verified fresh: tsc clean, lint 0 errors, vitest 46/46, **Playwright e2e 8/8** (7 desktop + the new mobile test).

Note: the full icon-only + hover-expand aesthetic from DESIGN.md is intentionally left for a visually-iterated pass; this PR delivers the responsive correctness fix.

https://claude.ai/code/session_01QwRSUQRhHR4mkfvvaoqnYJ