### PR TITLE
feat(ux): read-only detail view for every role incl. VIEWER (batch 11)

### DIFF
--- a/frontend/src/components/common/DetailModal.tsx
+++ b/frontend/src/components/common/DetailModal.tsx
@@ -1,0 +1,84 @@
+import { useId, useRef } from 'react';
+import type { ReactNode } from 'react';
+import { useModalA11y } from '../../hooks/useModalA11y';
+import { Button } from './Button';
+
+export interface DetailField {
+  label: string;
+  value: ReactNode;
+  /** Render the value in the tabular data font (IDs, numbers, dates). */
+  mono?: boolean;
+}
+
+interface DetailModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  title: string;
+  fields: DetailField[];
+}
+
+/**
+ * Read-only record detail dialog (works for every role, incl. VIEWER). Reuses the
+ * modal a11y behaviour; renders a label/value grid with the data font for values.
+ */
+export const DetailModal = ({ isOpen, onClose, title, fields }: DetailModalProps) => {
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const titleId = useId();
+  useModalA11y(isOpen, onClose, dialogRef);
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50 animate-backdrop"
+      onMouseDown={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        tabIndex={-1}
+        className="bg-white dark:bg-dark-surface rounded border border-clinical-border dark:border-white/10 w-full max-w-2xl max-h-[90vh] overflow-y-auto focus:outline-none"
+      >
+        <div className="flex items-center justify-between px-6 py-4 border-b border-clinical-border dark:border-white/10">
+          <h2 id={titleId} className="text-lg font-bold text-clinical-text dark:text-white">
+            {title}
+          </h2>
+          <button
+            onClick={onClose}
+            aria-label="Close dialog"
+            className="text-2xl leading-none text-clinical-secondary hover:text-clinical-text dark:hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-[#0055FF] rounded"
+          >
+            ×
+          </button>
+        </div>
+
+        <dl className="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-4 p-6">
+          {fields.map((f) => (
+            <div key={f.label}>
+              <dt className="text-xs font-semibold uppercase tracking-wide text-clinical-secondary">
+                {f.label}
+              </dt>
+              <dd
+                className={`mt-1 text-sm text-clinical-text dark:text-gray-200 break-words ${
+                  f.mono ? 'font-mono' : ''
+                }`}
+              >
+                {f.value === '' || f.value === null || f.value === undefined ? '—' : f.value}
+              </dd>
+            </div>
+          ))}
+        </dl>
+
+        <div className="flex justify-end px-6 py-4 border-t border-clinical-border dark:border-white/10">
+          <Button variant="secondary" onClick={onClose}>
+            Close
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/pages/Orders.tsx
+++ b/frontend/src/pages/Orders.tsx
@@ -5,6 +5,7 @@ import { Card } from '../components/common/Card';
 import { Button } from '../components/common/Button';
 import { ErrorBanner } from '../components/common/ErrorBanner';
 import { StatusBadge } from '../components/common/StatusBadge';
+import { DetailModal } from '../components/common/DetailModal';
 import { DeleteConfirmDialog } from '../components/common/DeleteConfirmDialog';
 import { OrderCreateModal } from '../components/Orders/OrderCreateModal';
 import { OrderEditModal } from '../components/Orders/OrderEditModal';
@@ -32,6 +33,7 @@ export const Orders = () => {
   const [selectedOrderId, setSelectedOrderId] = useState<string | null>(null);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const [orderToDelete, setOrderToDelete] = useState<Order | null>(null);
+  const [detailOrder, setDetailOrder] = useState<Order | null>(null);
   const itemsPerPage = 20;
 
   const { data: orders, total: totalOrders, loading, error, refetch } = useEntityList(
@@ -236,7 +238,22 @@ export const Orders = () => {
                           {new Date(order.requested_date).toLocaleDateString('de-DE')}
                         </td>
                         <td className="px-3 md:px-6 py-2 md:py-4 whitespace-nowrap text-right text-sm font-medium">
-                          {canWrite && <div className="flex items-center justify-end gap-2">
+                          <div className="flex items-center justify-end gap-2">
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              onClick={() => setDetailOrder(order)}
+                              title="View order details"
+                            >
+                              <span className="flex items-center gap-1">
+                                <svg className="w-4 h-4" fill="none" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" viewBox="0 0 24 24" stroke="currentColor">
+                                  <path d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                                  <path d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+                                </svg>
+                                View
+                              </span>
+                            </Button>
+                            {canWrite && <>
                             <Button
                               variant="secondary"
                               size="sm"
@@ -290,7 +307,8 @@ export const Orders = () => {
                                 Delete
                               </span>
                             </Button>
-                          </div>}
+                            </>}
+                          </div>
                         </td>
                       </tr>
                     ))}
@@ -408,6 +426,22 @@ export const Orders = () => {
         confirmText="Cancel Order"
         cancelText="Keep"
         outcomeNote="The order is marked CANCELLED (soft-delete). Its audit history is retained."
+      />
+
+      <DetailModal
+        isOpen={detailOrder !== null}
+        onClose={() => setDetailOrder(null)}
+        title={`Order ${detailOrder?.order_id ?? ''}`}
+        fields={detailOrder ? [
+          { label: 'Order ID', value: detailOrder.order_id, mono: true },
+          { label: 'Sample ID', value: detailOrder.sample_id, mono: true },
+          { label: 'Test Type', value: detailOrder.test_type },
+          { label: 'Status', value: detailOrder.status },
+          { label: 'Priority', value: detailOrder.priority },
+          { label: 'Requested By', value: detailOrder.requested_by },
+          { label: 'Requested', value: detailOrder.requested_date ? new Date(detailOrder.requested_date).toLocaleString('de-DE') : '', mono: true },
+          { label: 'Notes', value: detailOrder.notes },
+        ] : []}
       />
     </Layout>
   );

--- a/frontend/src/pages/Results.tsx
+++ b/frontend/src/pages/Results.tsx
@@ -5,6 +5,7 @@ import { Card } from '../components/common/Card';
 import { Button } from '../components/common/Button';
 import { ErrorBanner } from '../components/common/ErrorBanner';
 import { StatusBadge } from '../components/common/StatusBadge';
+import { DetailModal } from '../components/common/DetailModal';
 import { DeleteConfirmDialog } from '../components/common/DeleteConfirmDialog';
 import { ResultCreateModal } from '../components/Results/ResultCreateModal';
 import { ResultEditModal } from '../components/Results/ResultEditModal';
@@ -31,6 +32,7 @@ export const Results = () => {
   const [selectedResult, setSelectedResult] = useState<TestResult | null>(null);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const [resultToDelete, setResultToDelete] = useState<TestResult | null>(null);
+  const [detailResult, setDetailResult] = useState<TestResult | null>(null);
   const itemsPerPage = 20;
 
   const { data: results, total: totalResults, loading, error, refetch } = useEntityList(
@@ -230,7 +232,22 @@ export const Results = () => {
                           </StatusBadge>
                         </td>
                         <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium border-b border-[#E2E8F0]">
-                          {canWrite && <div className="flex items-center justify-end gap-2">
+                          <div className="flex items-center justify-end gap-2">
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              onClick={() => setDetailResult(result)}
+                              title="View result details"
+                            >
+                              <span className="flex items-center gap-1">
+                                <svg className="w-4 h-4" fill="none" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" viewBox="0 0 24 24" stroke="currentColor">
+                                  <path d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                                  <path d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+                                </svg>
+                                View
+                              </span>
+                            </Button>
+                            {canWrite && <>
                             <Button
                               variant="secondary"
                               size="sm"
@@ -281,7 +298,8 @@ export const Results = () => {
                                 Delete
                               </span>
                             </Button>
-                          </div>}
+                            </>}
+                          </div>
                         </td>
                       </tr>
                     ))}
@@ -365,6 +383,22 @@ export const Results = () => {
         itemName={resultToDelete?.result_id}
         confirmText="Reject"
         outcomeNote="The result is marked REJECTED (soft-delete). Its audit history is retained."
+      />
+
+      <DetailModal
+        isOpen={detailResult !== null}
+        onClose={() => setDetailResult(null)}
+        title={`Result ${detailResult?.result_id ?? ''}`}
+        fields={detailResult ? [
+          { label: 'Result ID', value: detailResult.result_id, mono: true },
+          { label: 'Order ID', value: detailResult.order_id, mono: true },
+          { label: 'Parameter', value: detailResult.parameter },
+          { label: 'Value', value: `${detailResult.value}${detailResult.unit ? ' ' + detailResult.unit : ''}`, mono: true },
+          { label: 'Reference Range', value: (detailResult.reference_min || detailResult.reference_max) ? `${detailResult.reference_min} – ${detailResult.reference_max}` : '', mono: true },
+          { label: 'Flag', value: detailResult.flag },
+          { label: 'Status', value: detailResult.status },
+          { label: 'Reviewed By', value: detailResult.reviewed_by },
+        ] : []}
       />
     </Layout>
   );

--- a/frontend/src/pages/Samples.tsx
+++ b/frontend/src/pages/Samples.tsx
@@ -4,6 +4,7 @@ import { Card } from '../components/common/Card';
 import { Button } from '../components/common/Button';
 import { ErrorBanner } from '../components/common/ErrorBanner';
 import { StatusBadge } from '../components/common/StatusBadge';
+import { DetailModal } from '../components/common/DetailModal';
 import { DeleteConfirmDialog } from '../components/common/DeleteConfirmDialog';
 import { SampleCreateModal } from '../components/Samples/SampleCreateModal';
 import { SampleEditModal } from '../components/Samples/SampleEditModal';
@@ -30,6 +31,7 @@ export const Samples = () => {
   const [selectedSampleId, setSelectedSampleId] = useState<string | null>(null);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const [sampleToDelete, setSampleToDelete] = useState<Sample | null>(null);
+  const [detailSample, setDetailSample] = useState<Sample | null>(null);
   const itemsPerPage = 20;
 
   const { data: samples, total: totalSamples, loading, error, refetch } = useEntityList(
@@ -219,7 +221,22 @@ export const Samples = () => {
                           {new Date(sample.created_at).toLocaleDateString('de-DE')}
                         </td>
                         <td className="px-3 md:px-6 py-2 md:py-4 whitespace-nowrap text-right text-sm font-medium">
-                          {canWrite && <div className="flex items-center justify-end gap-2">
+                          <div className="flex items-center justify-end gap-2">
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              onClick={() => setDetailSample(sample)}
+                              title="View sample details"
+                            >
+                              <span className="flex items-center gap-1">
+                                <svg className="w-4 h-4" fill="none" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" viewBox="0 0 24 24" stroke="currentColor">
+                                  <path d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                                  <path d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+                                </svg>
+                                View
+                              </span>
+                            </Button>
+                            {canWrite && <>
                             <Button
                               variant="secondary"
                               size="sm"
@@ -274,7 +291,8 @@ export const Samples = () => {
                                 Delete
                               </span>
                             </Button>
-                          </div>}
+                            </>}
+                          </div>
                         </td>
                       </tr>
                     ))}
@@ -365,6 +383,20 @@ export const Samples = () => {
         itemName={sampleToDelete?.sample_id}
         confirmText="Archive"
         outcomeNote="The sample is marked ARCHIVED (soft-delete). Its audit history is retained."
+      />
+
+      <DetailModal
+        isOpen={detailSample !== null}
+        onClose={() => setDetailSample(null)}
+        title={`Sample ${detailSample?.sample_id ?? ''}`}
+        fields={detailSample ? [
+          { label: 'Sample ID', value: detailSample.sample_id, mono: true },
+          { label: 'Patient ID', value: detailSample.patient_id, mono: true },
+          { label: 'Patient Name', value: detailSample.patient_name },
+          { label: 'Status', value: detailSample.status },
+          { label: 'Description', value: detailSample.description },
+          { label: 'Created', value: new Date(detailSample.created_at).toLocaleString('de-DE'), mono: true },
+        ] : []}
       />
     </Layout>
   );


### PR DESCRIPTION
Closes the last row-level gap: VIEWER could open nothing (the actions cell was entirely behind `canWrite`).

- New **DetailModal** — read-only record dialog (label/value grid, data font for values, dark-mode aware) on the shared modal a11y hook (focus-trap / Esc / focus-restore).
- A **View** action is now in the Samples/Orders/Results action cells for **all roles**; Edit/Delete remain ADMIN/OPERATOR-only.

Verified: tsc clean, lint 0 errors, vitest 46/46, Playwright e2e 8/8.

https://claude.ai/code/session_01QwRSUQRhHR4mkfvvaoqnYJ