### PR TITLE
docs: mark E2E workflows as tested

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -177,9 +177,10 @@ Aktuell getestet:
 - ✅ JWT-Authentifizierung & RBAC (Auth-Required- und abgelehnte-Rollen-Fälle)
 - ✅ HL7/FHIR-Parser, Statistik-Aggregation, Migrations, Audit-Hash-Chain
 - ✅ Frontend Components (46 Tests via Vitest + React Testing Library)
+- ✅ End-to-End Workflows (8 Playwright-Tests: Login, Navigation, API-Read,
+  Mobile-Drawer — starten echtes Backend + Frontend, laufen im CI)
 
 Noch nicht getestet:
-- ⏳ End-to-End Workflows (Playwright, e2e-Suite + CI-Job vorhanden)
 - ⏳ Performance unter Last
 - ⏳ CLI-Interface (schwierig automatisch zu testen)
 


### PR DESCRIPTION
Small doc fix + verification of the reconfigured branch ruleset: the e2e suite (8 Playwright tests) runs in CI, so it belongs in the 'currently tested' list, not 'not yet tested'.

This PR doubles as a check that a green PR now merges **without** an admin override under the new ruleset (PR required · 0 reviews · CI checks required).