### PR TITLE
docs: fix stale docs (versions, ports, dead links) + docs index

### DIFF
--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -1,7 +1,7 @@
 # OpenSylab Docker Deployment Guide
 
-**Version:** 0.7.0
-**Date:** 2026-05-11
+**Version:** 1.0.0
+**Date:** 2026-07-06
 **Status:** Production-Ready
 
 ---
@@ -22,7 +22,7 @@
 
 ## Overview
 
-OpenSylab v0.7+ provides full Docker support for easy deployment and scalability. The Docker setup includes:
+OpenSylab v1.0+ provides full Docker support for easy deployment and scalability. The Docker setup includes:
 
 - **Backend Container**: C++17 REST API server with SQLite
 - **Frontend Container**: React SPA served by nginx
@@ -61,7 +61,7 @@ OpenSylab v0.7+ provides full Docker support for easy deployment and scalability
 ```bash
 git clone https://github.com/AurevionSec/openSylab.git
 cd openSylab
-git checkout v0.7
+cp .env.example .env   # set OPENSYLAB_JWT_SECRET + OPENSYLAB_AUDIT_HMAC_KEY
 ```
 
 ### 2. Start the Stack
@@ -76,7 +76,7 @@ docker compose logs -f
 
 ### 3. Access the Application
 
-- **Frontend (Web UI)**: http://localhost
+- **Frontend (Web UI)**: http://localhost:9090
 - **Backend (API)**: http://localhost:9080/api/v1
 
 ### 4. Default Credentials
@@ -151,8 +151,9 @@ Both containers use **multi-stage builds** to minimize image size:
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `OPENSYLAB_DB_PATH` | `/app/data/opensylab.db` | SQLite database path |
-| `OPENSYLAB_API_PORT` | `8080` | API server port |
-| `OPENSYLAB_JWT_SECRET` | (development default) | **REQUIRED** JWT secret key (min. 32 chars) ⚠️ |
+| `OPENSYLAB_JWT_SECRET` | — | **Required** JWT signing key (min. 32 chars) ⚠️ |
+| `OPENSYLAB_AUDIT_HMAC_KEY` | — | **Required** HMAC key for the audit hash chain (min. 32 chars) ⚠️ — the container refuses to start without it |
+| `OPENSYLAB_CORS_ORIGIN` | `http://localhost:5173` | Allowed frontend origin |
 | `OPENSYLAB_TLS_CERT` | - | TLS certificate path (optional) |
 | `OPENSYLAB_TLS_KEY` | - | TLS private key path (optional) |
 
@@ -163,8 +164,8 @@ services:
   backend:
     environment:
       - OPENSYLAB_DB_PATH=/app/data/opensylab.db
-      - OPENSYLAB_API_PORT=8080
-      - OPENSYLAB_JWT_SECRET=your-secure-random-secret-min-32-characters
+      - OPENSYLAB_JWT_SECRET=${OPENSYLAB_JWT_SECRET:?set in .env}
+      - OPENSYLAB_AUDIT_HMAC_KEY=${OPENSYLAB_AUDIT_HMAC_KEY:?set in .env}
 ```
 
 **⚠️ IMPORTANT - JWT Secret Security:**
@@ -207,8 +208,8 @@ volumes:
 
 | Service | Container Port | Host Port | Description |
 |---------|----------------|-----------|-------------|
-| Frontend | 80 | 80 | Web UI (nginx) |
-| Backend | 8080 | 8080 | REST API |
+| Frontend | 80 | **9090** | Web UI (nginx) |
+| Backend | 8080 | **9080** | REST API |
 
 **Change host ports** in `docker-compose.yml`:
 
@@ -426,7 +427,7 @@ docker compose run --rm frontend npm test
 
 ```bash
 # Pull latest code
-git pull origin v0.7
+git pull
 
 # Rebuild containers
 docker compose build --no-cache
@@ -594,10 +595,10 @@ See `docs/KUBERNETES.md` (planned for v1.0+).
 
 - **GitHub Issues**: https://github.com/AurevionSec/openSylab/issues
 - **Discussions**: https://github.com/AurevionSec/openSylab/discussions
-- **Email**: A@Eddelbuet.tel
+- **Issues**: https://github.com/AurevionSec/openSylab/issues
 
 ---
 
-**Last Updated:** 2026-02-11
-**OpenSylab Version:** v0.7.0
+**Last Updated:** 2026-07-06
+**OpenSylab Version:** v1.0.0
 **Document Version:** 1.2

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -143,7 +143,7 @@ cp data/opensylab.db data/backup_$(date +%Y%m%d_%H%M%S).db
 
 Für Produktionsumgebungen:
 
-1. **HTTPS/TLS konfigurieren** (siehe [TLS_SETUP.md](TLS_SETUP.md))
+1. **HTTPS/TLS konfigurieren** (siehe [README → Configuration](../README.md) und [SECRET_ROTATION.md](SECRET_ROTATION.md))
 2. **Secrets externalisieren** (Environment Variables)
 3. **Reverse Proxy** (nginx/traefik) verwenden
 4. **Regelmäßige Backups** einrichten
@@ -333,7 +333,9 @@ openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -days 365 -node
 ```bash
 # Backend
 export OPENSYLAB_DB_PATH=/pfad/zur/datenbank.db
-export OPENSYLAB_JWT_SECRET=your-super-secret-key-here
+export OPENSYLAB_JWT_SECRET="$(openssl rand -hex 32)"       # Pflicht in Prod (>=32 Zeichen)
+export OPENSYLAB_AUDIT_HMAC_KEY="$(openssl rand -hex 32)"   # Pflicht in Prod — Server startet sonst nicht
+export OPENSYLAB_CORS_ORIGIN=https://lims.example.org       # erlaubte Frontend-Origin
 export OPENSYLAB_TLS_CERT=/pfad/zu/cert.pem
 export OPENSYLAB_TLS_KEY=/pfad/zu/key.pem
 
@@ -341,12 +343,12 @@ export OPENSYLAB_TLS_KEY=/pfad/zu/key.pem
 export VITE_API_URL=http://localhost:8080/api/v1
 ```
 
-### Konfigurationsdatei (v0.8.0+)
+### Konfigurationsdatei
 
-Ab v0.8.0 wird eine Konfigurationsdatei unterstützt:
+OpenSylab unterstützt eine optionale Konfigurationsdatei:
 
 ```ini
-# opensylab.conf (verfügbar seit v0.8.0)
+# opensylab.conf
 [database]
 path = /var/lib/opensylab/opensylab.db
 
@@ -571,7 +573,7 @@ curl http://localhost:8080/api/v1/stats
 
 ## 📚 Weitere Ressourcen
 
-- **[README.MD](../README.MD)** - Projektübersicht und Features
+- **[README.md](../README.md)** - Projektübersicht und Features
 - **[ROADMAP.MD](../ROADMAP.MD)** - Entwicklungs-Roadmap
 - **[CHANGELOG.md](../CHANGELOG.md)** - Versionshistorie
 - **[TODO.md](../TODO.md)** - Geplante Features
@@ -626,4 +628,4 @@ npm run build
 
 **Version:** 1.0.0
 **Letzte Aktualisierung:** 2026-07-05
-**Nächste Version:** 1.1.0 (PostgreSQL-Backend, Multi-Site)
+**Roadmap:** siehe [ROADMAP.md](../ROADMAP.md) — geplant u.a. PostgreSQL-Backend und Multi-Site.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,21 @@
+# OpenSylab documentation
+
+Start here to find your way around the docs.
+
+| Guide | What it covers |
+|-------|----------------|
+| [INSTALL.md](INSTALL.md) | Install & run — Docker and native build-from-source |
+| [DOCKER.md](DOCKER.md) | Docker deployment in depth (compose, ports, volumes, production) |
+| [SECRET_ROTATION.md](SECRET_ROTATION.md) | Managing and rotating `OPENSYLAB_JWT_SECRET` / `OPENSYLAB_AUDIT_HMAC_KEY` |
+| [openapi.yaml](openapi.yaml) | Machine-readable REST API contract (load in Swagger UI / Redoc) |
+| [TESTING.md](TESTING.md) | Test suite: backend unit, frontend (Vitest), end-to-end (Playwright) |
+| [VERSIONING.md](VERSIONING.md) | Version single-source-of-truth and the release process |
+
+**Also useful:** the [README](../README.md) (overview, quick start, configuration, architecture) · the [ROADMAP](../ROADMAP.md) · the [CHANGELOG](../CHANGELOG.md) · [CONTRIBUTING](../CONTRIBUTING.md) · [SECURITY](../SECURITY.md).
+
+## Quick reference
+
+- **Health check:** `GET /api/v1/health` → `{"status":"ok","service":"opensylab-lims"}`
+- **Ports (Docker):** frontend `9090`, backend `9080` · **native default:** backend `8080`
+- **Required production secrets:** `OPENSYLAB_JWT_SECRET`, `OPENSYLAB_AUDIT_HMAC_KEY` (≥ 32 chars each; `openssl rand -hex 32`)
+- **Default login:** `admin` / `admin` — development only, change immediately

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -269,54 +269,32 @@ Für CI/CD-Pipelines:
 
 Der Exit-Code ist 0 bei Erfolg, 1 bei Fehler.
 
-## Zukünftige Erweiterungen
+## Bereits geliefert (Stand v1.0.0)
 
-### v0.8.0 (Nächste Version):
-- **Integration Tests**: API-Endpoint-Tests mit curl/Postman
-- **Frontend Tests**: Jest + React Testing Library
-  - Component Tests
-  - Authentication Context Tests
-  - Protected Routes Tests
-- **RBAC Tests**: Role-based access control validation
-- **JWT Auth Tests**: Token generation and validation
+- **Frontend-Unit-Tests** — 46 Tests via Vitest + React Testing Library (Components, Auth-Context, Protected Routes).
+- **RBAC- & JWT-Auth-Tests** — Auth-Required- und abgelehnte-Rollen-Fälle im Backend.
+- **End-to-End-Tests** — 8 Playwright-Tests (Login, Navigation, API-Read, Mobile-Drawer), starten echtes Backend + Frontend.
+- **CI/CD-Pipeline** — GitHub Actions führt Backend-, Frontend- und E2E-Tests bei jedem Push/PR aus.
 
-### v0.9.0+:
-- **E2E Tests**: Cypress oder Playwright für End-to-End Workflows
-- **Performance Tests**: Load testing mit K6 oder Artillery
-- **Code Coverage**: gcov/lcov für C++ Backend
-- **CI/CD Pipeline**: GitHub Actions automatisierte Tests
-- **Mock Objects**: Bessere Test-Isolierung
-- **API Contract Tests**: OpenAPI Schema Validation
-
-### Frontend Testing (v0.8.0+):
+### Frontend-Tests ausführen
 
 ```bash
 cd frontend
-
-# Unit Tests
-npm test
-
-# Watch Mode
-npm test -- --watch
-
-# Coverage Report
-npm run test:coverage
-
-# E2E Tests (v0.9.0+)
-npm run test:e2e
+npm test              # Vitest Unit-Tests
+npm test -- --watch   # Watch-Mode
+npm run test:e2e      # Playwright E2E (startet Backend + Frontend selbst)
 ```
 
-### API Testing (v0.8.0+):
+### Manueller API-Smoke-Test
 
 ```bash
-# Postman Collection
-newman run tests/api/opensylab-api.postman_collection.json
-
-# Manual API Tests
 curl -X POST http://localhost:8080/api/v1/auth/login \
   -H "Content-Type: application/json" \
   -d '{"username":"admin","password":"admin"}'
-
-# Integration Test Suite
-./scripts/run-api-tests.sh
 ```
+
+## Geplant
+
+- **Code-Coverage-Reporting** (gcov/lcov für das C++-Backend, `npm run test:coverage` fürs Frontend).
+- **Last-/Performance-Tests** (z. B. k6).
+- **API-Contract-Tests** gegen `docs/openapi.yaml`.

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -10,7 +10,7 @@ Quellen automatisch — keine manuellen Anpassungen nötig.
 
 ```
 CMakeLists.txt                     frontend/package.json
-  project(OpenSylab VERSION 0.7.0)   "version": "0.7.0"
+  project(OpenSylab VERSION 1.0.0)   "version": "1.0.0"
          │                                    │
          ▼ cmake configure_file              ▼ vite define (vite.config.ts)
    include/version.h               import.meta.env.VITE_APP_VERSION
@@ -24,7 +24,7 @@ CMakeLists.txt                     frontend/package.json
 
 ```cmake
 project(OpenSylab
-    VERSION 0.7.0          # ← HIER ändern für neues Release
+    VERSION 1.0.0          # ← HIER ändern für neues Release
     DESCRIPTION "..."
     LANGUAGES CXX
 )
@@ -41,8 +41,8 @@ CMake generiert beim Konfigurieren `include/version.h` aus dem Template
 
 | Makro | Beispielwert |
 |-------|-------------|
-| `OPENSYLAB_VERSION` | `"0.7.0"` |
-| `OPENSYLAB_VERSION_STRING` | `"OpenSylab v0.7.0"` |
+| `OPENSYLAB_VERSION` | `"1.0.0"` |
+| `OPENSYLAB_VERSION_STRING` | `"OpenSylab v1.0.0"` |
 | `OPENSYLAB_VERSION_MAJOR` | `0` |
 | `OPENSYLAB_VERSION_MINOR` | `7` |
 | `OPENSYLAB_VERSION_PATCH` | `0` |
@@ -52,7 +52,7 @@ Verwendung in C++:
 ```cpp
 #include "version.h"
 
-std::cout << OPENSYLAB_VERSION_STRING << "\n";  // "OpenSylab v0.7.0"
+std::cout << OPENSYLAB_VERSION_STRING << "\n";  // "OpenSylab v1.0.0"
 ```
 
 ### Frontend — `package.json`
@@ -60,7 +60,7 @@ std::cout << OPENSYLAB_VERSION_STRING << "\n";  // "OpenSylab v0.7.0"
 ```json
 {
   "name": "frontend",
-  "version": "0.7.0"    ← HIER ändern für neues Release
+  "version": "1.0.0"    ← HIER ändern für neues Release
 }
 ```
 
@@ -79,7 +79,7 @@ export default defineConfig({
 Verwendung im Frontend:
 
 ```tsx
-<span>{import.meta.env.VITE_APP_VERSION}</span>  {/* "0.7.0" */}
+<span>{import.meta.env.VITE_APP_VERSION}</span>  {/* "1.0.0" */}
 ```
 
 > **Hinweis:** `VITE_APP_VERSION` ist ein Build-Zeit-Wert — er ist hartcodiert im
@@ -91,7 +91,7 @@ Verwendung im Frontend:
 
 ```bash
 # 1. Beide SSoTs aktualisieren
-#    CMakeLists.txt: VERSION 0.7.0 → 0.8.0
+#    CMakeLists.txt: VERSION 1.0.0 → 1.1.0
 #    frontend/package.json: "version": "0.8.0"
 
 # 2. C++ neu bauen (generiert version.h)
@@ -130,4 +130,4 @@ OpenSylab folgt [Semantic Versioning 2.0.0](https://semver.org):
 | Neue Features, abwärtskompatibel | `MINOR` |
 | Bugfixes, Sicherheitspatches | `PATCH` |
 
-Aktuelle Version: **0.7.0** — Pre-1.0, API kann sich ändern.
+Aktuelle Version: **1.0.0** — stabil; die API folgt ab 1.0 SemVer (Breaking Changes nur in Major-Releases).


### PR DESCRIPTION
Batch 2 of the outward-presentation pass — factual documentation fixes.

- **DOCKER.md** was a full version behind (0.7.0, `git checkout v0.7`, wrong ports 80/8080, missing mandatory HMAC key). Now 1.0.0, correct host ports (9090/9080), complete env table.
- **VERSIONING.md** stale at 0.7.0 + "Pre-1.0 API may change" → 1.0.0 / SemVer-stable.
- **TESTING.md** listed shipped features (frontend tests, E2E, CI) as "future work" → accurate Delivered/Planned split.
- **INSTALL.md** dead links fixed (TLS_SETUP.md, README.MD case); mandatory HMAC/CORS env added.
- New **docs/README.md** index.

https://claude.ai/code/session_01QwRSUQRhHR4mkfvvaoqnYJ